### PR TITLE
Implement basic acceleration and deceleration in DBW controller

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -59,7 +59,7 @@ class DBWNode(object):
 
         # Create `Controller` object
         self.controller = Controller(
-            wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle)
+            wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle, decel_limit, accel_limit, fuel_capacity, vehicle_mass, wheel_radius)
 
         # Subscribe to messages about car being under drive by wire control
         rospy.Subscriber(
@@ -108,6 +108,8 @@ class DBWNode(object):
         self.dbw_enabled = dbw_enabled_message.data
         rospy.loginfo(
             'Drive by Wire %s', "enabled" if self.dbw_enabled else "disabled")
+        if (not self.dbw_enabled):
+            self.controller.reset()
 
     def handle_target_velocity_message(self, twist_velocity_command_message):
         twist = twist_velocity_command_message.twist

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,3 +1,8 @@
+import time
+
+import rospy
+
+from pid import PID
 from yaw_controller import YawController
 
 GAS_DENSITY = 2.858
@@ -6,12 +11,46 @@ ONE_MPH = 0.44704
 
 class Controller(object):
 
-    def __init__(self, wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle):
+    def __init__(self, wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle, max_deceleration, max_acceleration, fuel_capacity, vehicle_mass, wheel_radius):
+        self.fuel_capacity = fuel_capacity
+        self.vehicle_mass = vehicle_mass
+        self.wheel_radius = wheel_radius
+        self.current_timestep = None
+
         self.yaw_controller = YawController(
             wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle)
 
+        self.velocity_pid_controller = PID(
+            0.1, 0.000005, 0.05, max_deceleration, max_acceleration)
+
     def control(self, target_linear_velocity, target_angular_velocity, current_linear_velocity):
-        # TODO - implement proper throttle and brake measurements
+        # use velocity pid controller to compute new velocity
+        acceleration = self.compute_acceleration(
+            target_linear_velocity - current_linear_velocity)
+        rospy.logdebug('Current linear velocity %s, target linear velocity %s, computed acceleration %s',
+                       current_linear_velocity, target_linear_velocity, acceleration)
 
         # Return throttle, brake, steer
-        return 0., 0., self.yaw_controller.get_steering(target_linear_velocity, target_angular_velocity, current_linear_velocity)
+        return (acceleration if acceleration > 0. else 0.,
+                self.compute_brake_torque(abs(acceleration)) if acceleration < 0. else 0.,
+                self.yaw_controller.get_steering(target_linear_velocity, target_angular_velocity, current_linear_velocity))
+
+    def reset(self):
+        self.last_timestep = None
+        self.velocity_pid_controller.reset()
+
+    def compute_acceleration(self, error):
+        last_timestep = self.current_timestep
+        self.current_timestep = int(round(time.time() * 1000))
+        
+        # TODO - modify PID instance to modify error value to prevent sudden control jumps when re-engaging DBW
+        # after a period of inactivity
+        if last_timestep is None:
+            # attempted to compute values for first time; do not accellerate
+            return 0.
+
+        return self.velocity_pid_controller.step(error, self.current_timestep - last_timestep)
+
+    def compute_brake_torque(self, deceleration):
+        # deceleration in m/s^2 needs to be converted to torque in Nm.
+        return (self.vehicle_mass + self.fuel_capacity * GAS_DENSITY) * deceleration * self.wheel_radius


### PR DESCRIPTION
Incredibly basic throttle and brake controller.

* PID control for acceleration with handpicked P, I, D coefficients, limited by max acceleration and deceleration.
* State reset when DBW is turned off, so that accumulated state in PID controller is removed for when (if)DBW is turned back on again.
* No feed-forward yet as recommended in [previous review](https://github.com/team-fusionx/CarND-Capstone/pull/14#discussion_r172743302), but this is just a very basic implementation to get us started.

Tested locally with simulator - throttle and braking seem to work nicely! It's revealed some choppiness with steering, which will be addressed in a future PR.