### PR TITLE
Waypoint Follower: Search for closest waypoint to current pose

### DIFF
--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -70,6 +70,9 @@ private:
   bool pose_set_;
   bool velocity_set_;
   int num_of_next_waypoint_;
+  // edufford start
+  int closest_waypoint_idx_; // index of closest waypoint to current pose
+  // edufford end
   geometry_msgs::Point position_of_next_target_;
   double lookahead_distance_;
 
@@ -84,6 +87,9 @@ private:
   bool interpolateNextTarget(int next_waypoint, geometry_msgs::Point *next_target) const;
   bool verifyFollowing() const;
   geometry_msgs::Twist calcTwist(double curvature, double cmd_velocity) const;
+  // edufford start
+  void getClosestWaypoint(); // find closest waypoint to current pose
+  // edufford end
   void getNextWaypoint();
   geometry_msgs::TwistStamped outputZero() const;
   geometry_msgs::TwistStamped outputTwist(geometry_msgs::Twist t) const;

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -70,9 +70,7 @@ private:
   bool pose_set_;
   bool velocity_set_;
   int num_of_next_waypoint_;
-  // edufford start
   int closest_waypoint_idx_; // index of closest waypoint to current pose
-  // edufford end
   geometry_msgs::Point position_of_next_target_;
   double lookahead_distance_;
 
@@ -87,9 +85,7 @@ private:
   bool interpolateNextTarget(int next_waypoint, geometry_msgs::Point *next_target) const;
   bool verifyFollowing() const;
   geometry_msgs::Twist calcTwist(double curvature, double cmd_velocity) const;
-  // edufford start
   void getClosestWaypoint(); // find closest waypoint to current pose
-  // edufford end
   void getNextWaypoint();
   geometry_msgs::TwistStamped outputZero() const;
   geometry_msgs::TwistStamped outputTwist(geometry_msgs::Twist t) const;
@@ -110,6 +106,7 @@ public:
     , pose_set_(false)
     , velocity_set_(false)
     , num_of_next_waypoint_(-1)
+    , closest_waypoint_idx_(-1)
     , lookahead_distance_(0)
   {
   }

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -292,24 +292,35 @@ geometry_msgs::Twist PurePursuit::calcTwist(double curvature, double cmd_velocit
 // Search for closest waypt from current pose
 void PurePursuit::getClosestWaypoint() {
   int path_size = static_cast<int>(current_waypoints_.getSize());
-  double min_dist = std::numeric_limits<double>::max();
+  int closest_wp = path_size - 1;
 
-  // if waypoints are not given, do nothing.
+  // If waypoints are not given, do nothing
   if (path_size == 0) {
     closest_waypoint_idx_ = -1;
     return;
   }
 
-  // look for the closest waypoint.
-  for (int i = 0; i < path_size; i++) {
+  // Initialize distance to first waypoint
+  double dist = getPlaneDistance(current_waypoints_.getWaypointPosition(0),
+                                 current_pose_.pose.position);
+
+  // Search for a closer waypoint
+  for (int i = 1; i < path_size; i++) {
     double t_dist = getPlaneDistance(current_waypoints_.getWaypointPosition(i),
                                      current_pose_.pose.position);
-    if (t_dist < min_dist) {
-      closest_waypoint_idx_ = i;
-      min_dist = t_dist;
+    if (t_dist < dist) {
+      // Found a closer waypoint, store dist and keep searching
+      dist = t_dist;
+    } else {
+      // Distance is not decreasing, prev waypt was closest so stop searching
+      closest_wp = i - 1;
+      break;
     }
   }
-  //ROS_ERROR_STREAM("wp = " << closest_waypoint_idx_ << " dist = " << min_dist);
+
+  // Store closest waypoint as output
+  closest_waypoint_idx_ = closest_wp;
+  //ROS_ERROR_STREAM("wp = " << closest_waypoint_idx_ << " dist = " << dist);
   return;
 }
 // edufford end

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -234,8 +234,6 @@ bool PurePursuit::verifyFollowing() const
   double a = 0;
   double b = 0;
   double c = 0;
-  // edufford start
-  //getLinearEquation(current_waypoints_.getWaypointPosition(1), current_waypoints_.getWaypointPosition(2), &a, &b, &c);
 
   // Use next 2 waypts from current pose to make a line seg to check
   int next_wp = closest_waypoint_idx_ + 1;
@@ -243,16 +241,12 @@ bool PurePursuit::verifyFollowing() const
   getLinearEquation(current_waypoints_.getWaypointPosition(next_wp),
                     current_waypoints_.getWaypointPosition(next_next_wp),
                     &a, &b, &c);
-  // edufford end
 
   double displacement = getDistanceBetweenLineAndPoint(current_pose_.pose.position, a, b, c);
-  // edufford start
-  //double relative_angle = getRelativeAngle(current_waypoints_.getWaypointPose(1), current_pose_.pose);
 
   // Use angle from current pose to next waypoint to check
   double relative_angle = getRelativeAngle(current_waypoints_.getWaypointPose(next_wp),
                                            current_pose_.pose);
-  // edufford end
 
   //ROS_ERROR("side diff : %lf , angle diff : %lf",displacement,relative_angle);
   if (displacement < displacement_threshold_ && relative_angle < relative_angle_threshold_)
@@ -288,11 +282,9 @@ geometry_msgs::Twist PurePursuit::calcTwist(double curvature, double cmd_velocit
   return twist;
 }
 
-// edufford start
 // Search for closest waypt from current pose
 void PurePursuit::getClosestWaypoint() {
   int path_size = static_cast<int>(current_waypoints_.getSize());
-  int closest_wp = path_size - 1;
 
   // If waypoints are not given, do nothing
   if (path_size == 0) {
@@ -301,6 +293,7 @@ void PurePursuit::getClosestWaypoint() {
   }
 
   // Initialize distance to first waypoint
+  int closest_wp = path_size - 1;
   double dist = getPlaneDistance(current_waypoints_.getWaypointPosition(0),
                                  current_pose_.pose.position);
 
@@ -323,7 +316,6 @@ void PurePursuit::getClosestWaypoint() {
   //ROS_ERROR_STREAM("wp = " << closest_waypoint_idx_ << " dist = " << dist);
   return;
 }
-// edufford end
 
 void PurePursuit::getNextWaypoint()
 {
@@ -418,10 +410,8 @@ geometry_msgs::TwistStamped PurePursuit::go()
 
   calcLookaheadDistance(1);
 
-  // edufford start
   // Search for closest waypoint to current pose
   getClosestWaypoint();
-  // edufford end
 
   // search next waypoint
   getNextWaypoint();
@@ -438,11 +428,8 @@ geometry_msgs::TwistStamped PurePursuit::go()
   {
     position_of_next_target_ = current_waypoints_.getWaypointPosition(num_of_next_waypoint_);
 
-    // edufford start
-    //return outputTwist(calcTwist(calcCurvature(position_of_next_target_), getCmdVelocity(0)));
     return outputTwist(calcTwist(calcCurvature(position_of_next_target_),
                                  getCmdVelocity(closest_waypoint_idx_)));
-    // edufford end
   }
 
   // linear interpolation and calculate angular velocity
@@ -456,11 +443,8 @@ geometry_msgs::TwistStamped PurePursuit::go()
 
   // ROS_INFO("next_target : ( %lf , %lf , %lf)", next_target.x, next_target.y,next_target.z);
 
-  // edufford start
-  //return outputTwist(calcTwist(calcCurvature(position_of_next_target_), getCmdVelocity(0)));
   return outputTwist(calcTwist(calcCurvature(position_of_next_target_),
                                getCmdVelocity(closest_waypoint_idx_)));
-  // edufford end
 
 // ROS_INFO("linear : %lf, angular : %lf",twist.twist.linear.x,twist.twist.angular.z);
 


### PR DESCRIPTION
Implement simple brute force search for closest waypoint to current pose instead of assuming waypoint index 0 is always the closest since waypoint_updater may have slower cycle time than waypoint_follower.  This is toward issue #20.