### PR TITLE
First Pass at stopping at lights with simple deceleration

### DIFF
--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -20,9 +20,12 @@ class WaypointLoader(object):
     def __init__(self):
         rospy.init_node('waypoint_loader', log_level=rospy.DEBUG)
 
-        self.pub = rospy.Publisher('/base_waypoints', Lane, queue_size=1, latch=True)
+        self.pub = rospy.Publisher('/base_waypoints', Lane, queue_size=1,
+                                   latch=True)
 
         self.velocity = self.kmph2mps(rospy.get_param('~velocity'))
+        rospy.loginfo("waypoint_loader:init velocity set to {} mps"
+                      .format(self.velocity))
         self.new_waypoint_loader(rospy.get_param('~path'))
         rospy.spin()
 
@@ -30,7 +33,7 @@ class WaypointLoader(object):
         if os.path.isfile(path):
             waypoints = self.load_waypoints(path)
             self.publish(waypoints)
-            rospy.loginfo('Waypoint Loded')
+            rospy.loginfo('Waypoint Loaded')
         else:
             rospy.logerr('%s is not a file', path)
 
@@ -64,7 +67,8 @@ class WaypointLoader(object):
         last = waypoints[-1]
         last.twist.twist.linear.x = 0.
         for wp in waypoints[:-1][::-1]:
-            dist = self.distance(wp.pose.pose.position, last.pose.pose.position)
+            dist = self.distance(wp.pose.pose.position,
+                                 last.pose.pose.position)
             vel = math.sqrt(2 * MAX_DECEL * dist)
             if vel < 1.:
                 vel = 0.

--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -6,11 +6,13 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+gen.add("dyn_test_stoplight_wp",   int_t, 0, "TESTING next stopline wp",
+        759, 0, 11010)
 gen.add("dyn_update_rate",         int_t, 0, "An Integer parameter",
         10, 1, 50)
 gen.add("dyn_lookahead_wps",       int_t, 0, "number of final waypoints",
         200, 10,  500)
 gen.add("dyn_default_velocity", double_t, 0, "speed to use",
-        5.0, 0.0, 100.0)
+        20.0, 0.0, 100.0)
 
 exit(gen.generate(PACKAGE, "waypoint_updater", "DynReconf"))

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -5,10 +5,11 @@
 
 import rospy
 import math
+import copy
 
 from geometry_msgs.msg import PoseStamped, TwistStamped
-from styx_msgs.msg import Lane, Waypoint
-from std_msgs.msg import String
+from styx_msgs.msg import Lane, Waypoint, TrafficLightArray, TrafficLight
+from std_msgs.msg import String, Int32
 from dynamic_reconfigure.server import Server
 from waypoint_updater.cfg import DynReconfConfig
 
@@ -35,6 +36,7 @@ class WaypointUpdater(object):
         self.waypoints = []
         self.pose = None
         self.velocity = None
+        self.lights = None
         self.final_waypoints = []
         self.final_waypoints_start_ptr = 0
         self.back_search = False
@@ -42,31 +44,36 @@ class WaypointUpdater(object):
         self.last_search_time = None
         self.next_traffic_light_wp = None
         self.update_rate = 10
-        self.default_velocity = 5.0
+        self.max_velocity = 0.0
+        self.default_velocity = 10.0
         self.lookahead_wps = 200
         self.subs = {}
         self.pubs = {}
+        self.dyn_reconf_srv = None
 
         rospy.init_node('waypoint_updater')
 
-        self.subs['/current_pose'] = \
-            rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-
         self.subs['/base_waypoints'] = \
             rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+
+        self.subs['/current_pose'] = \
+            rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
 
         self.subs['/current_velocity'] = \
             rospy.Subscriber('/current_velocity', TwistStamped,
                              self.velocity_cb)
 
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint
-        # self.subs['/traffic_waypoint'] = \
-        #      rospy.Subscriber('/traffic_waypoint', String, self.traffic_cb)
+        self.subs['/traffic_waypoint'] = \
+            rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
+
+        # TODO: Add a subscriber for /obstacle_waypoint
 
         self.pubs['/final_waypoints'] = rospy.Publisher('/final_waypoints',
                                                         Lane, queue_size=1)
 
-        self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
+        # self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
+        # move to waypoints_cb so no collision - seems like a bad idea but
+        # convenient for now
 
         self.loop()
 
@@ -91,24 +98,36 @@ class WaypointUpdater(object):
             old_update_rate = self.update_rate
             old_default_velocity = self.default_velocity
             old_lookahead_wps = self.lookahead_wps
+            old_test_stoplight_wp = self.next_traffic_light_wp
+        # end if
 
         rospy.loginfo("Received dynamic parameters {} with level: {}"
                       .format(config, level))
 
         if old_update_rate != config['dyn_update_rate']:
-            rospy.loginfo("waypoint_updater:dyn_vars_cb Adjusting update Rate \
-                           from {} to {}".format(old_update_rate,
+            rospy.loginfo("waypoint_updater:dyn_vars_cb Adjusting update Rate "
+                          "from {} to {}".format(old_update_rate,
                                                  config['dyn_update_rate']))
             self.update_rate = config['dyn_update_rate']
             # need to switch the delay
             self.rate = rospy.Rate(self.update_rate)
+        # end if
 
         if old_default_velocity != config['dyn_default_velocity']:
             rospy.loginfo("waypoint_updater:dyn_vars_cb Adjusting default_"
                           "velocity from {} to {}"
                           .format(old_default_velocity,
                                   config['dyn_default_velocity']))
-            self.default_velocity = config['dyn_default_velocity']
+
+            if config['dyn_default_velocity'] > self.max_velocity:
+                rospy.logwarn("waypoint_updater:dyn_vars_cb default_velocity "
+                              "limited to max_velocity {}"
+                              .format(self.max_velocity))
+                self.default_velocity = self.max_velocity
+            else:
+                self.default_velocity = config['dyn_default_velocity']
+            # end if
+        # end if
 
         if old_lookahead_wps != config['dyn_lookahead_wps']:
             rospy.loginfo("waypoint_updater:dyn_vars_cb Adjusting lookahead_"
@@ -116,6 +135,16 @@ class WaypointUpdater(object):
                           .format(old_lookahead_wps,
                                   config['dyn_lookahead_wps']))
             self.lookahead_wps = config['dyn_lookahead_wps']
+        # end if
+
+        if old_test_stoplight_wp != config['dyn_test_stoplight_wp']:
+            rospy.logwarn("waypoint_updater:dyn_vars_cb Adjusting next "
+                          "stoplight from {} to {}"
+                          .format(old_test_stoplight_wp,
+                                  config['dyn_test_stoplight_wp']))
+            self.next_traffic_light_wp = config['dyn_test_stoplight_wp']
+        # end if
+
         # we can also send adjusted values back
         return config
 
@@ -124,27 +153,108 @@ class WaypointUpdater(object):
 
     def pose_cb(self, pose_msg):
         self.pose = pose_msg.pose
-        rospy.loginfo("waypoint_updater:pose_cb pose set to  %s", self.pose)
+        rospy.logdebug("waypoint_updater:pose_cb pose set to  %s", self.pose)
 
+    # Load set of waypoints from /basewaypoints into self.waypoints
+    # this should only happen once, so we unsubscribe at end
     def waypoints_cb(self, lane_msg):
         rospy.loginfo("waypoint_updater:waypoints_cb loading waypoints")
         if not self.waypoints:
+            max_velocity = 0.0
             for waypoint in lane_msg.waypoints:
                 self.waypoints.append(waypoint)
+                if max_velocity < self.get_waypoint_velocity(waypoint):
+                    max_velocity = self.get_waypoint_velocity(waypoint)
+                # end if
             rospy.loginfo("waypoint_updater:waypoints_cb %d waypoints loaded",
                           len(self.waypoints))
+            # setting max velocity based on project requirements in
+            # Waypoint Updater Node Revisited
+            self.max_velocity = max_velocity
+            rospy.loginfo("waypoint_updater:waypoints_cb max_velocity set to "
+                          " {} based on max value in waypoints."
+                          .format(self.max_velocity))
+            # now max_velocity is known, set up dynamic reconfig
+            if not self.dyn_reconf_srv:
+                self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
+                rospy.loginfo("dynamic_parm server started")
+            # end if
         else:
             rospy.logerr("waypoint_updater:waypoints_cb attempt to load "
                          "waypoints when we have already loaded %d waypoints",
                          len(self.waypoints))
-
+        # end if else
         self.subs['/base_waypoints'].unregister()
         rospy.loginfo("Unregistered from /base_waypoints topic")
 
+    # Receive a msg from /traffic_waypoint about the next stop line
     def traffic_cb(self, traffic_msg):
-        # TODO: Callback for /traffic_waypoint message. Implement
-        # self.next_traffic_light_wp = traffic_msg.data
-        pass
+        if traffic_msg.data != self.next_traffic_light_wp:
+            # do we need to queue these or will I only get the next one
+            # coming up?
+            # If car is stopped do I need to ramp up velocity, then
+            # down to reach it?
+            self.next_traffic_light_wp = traffic_msg.data
+            rospy.loginfo("new /traffic_waypoint message received at wp: %d."
+                          "while car is at wp %d", self.next_traffic_light_wp,
+                          self.final_waypoints_start_ptr)
+        else:
+            # just for debug to see what we're getting
+            rospy.loginfo("same /traffic_waypoint message received.")
+
+    # adjust the velocities in the /final_waypoint queue
+    # TODO: move the waypoints to a structure there first so don't have to
+    # worry about looping
+    def set_waypoints_velocity(self):
+        # this can happen before we get a traffic_wp msg
+        if not self.next_traffic_light_wp:
+            # set one up behind car - is this a problem if we reverse?
+            # STUB in putting it at 759 to see if it works
+            # next_traffic_light_wp = self.final_waypoints_start_ptr - 1
+            self.next_traffic_light_wp = 759
+            next_traffic_light_wp = self.next_traffic_light_wp
+        else:
+            next_traffic_light_wp = self.next_traffic_light_wp
+        # end if else
+        if ((next_traffic_light_wp - self.final_waypoints_start_ptr) %
+                len(self.waypoints)) < 100:
+            start_ptr = self.final_waypoints_start_ptr + 5
+            end_ptr = next_traffic_light_wp
+            distance_to_rl = self.distance(start_ptr, end_ptr)
+            velocity = self.waypoints[start_ptr].twist.twist.linear.x
+            # time_to_decel = 2 * distance_to_rl / velocity
+            # accel = - velocity / time_to_decel
+            chord_dist = 0
+            final_end_ptr = self.final_waypoints_start_ptr + self.lookahead_wps
+            if distance_to_rl < 1.0:  # small buffer from stop line
+                for ptr in range(start_ptr, final_end_ptr):
+                    mod_ptr = ptr % len(self.waypoints)
+                    self.waypoints[mod_ptr].twist.twist.linear.x = 0.0
+                # end for
+            else:
+                for ptr in range(start_ptr, final_end_ptr):
+                    # self.next_traffic_light_wp):
+                    mod_ptr = ptr % len(self.waypoints)
+                    chord_dist += self.distance(ptr, ptr+1)
+                    v = (1-chord_dist/distance_to_rl)*velocity
+                    if v < 0.9:
+                        v = 0.0
+                    self.waypoints[mod_ptr].twist.twist.linear.x = v
+                # end for
+            # end if else
+        else:
+            # if self.velocity < self.default_velocity:
+            #    waypoints[self.final_waypoints_start_ptr + 5].twist.twist.\
+            #        linear.x == self.velocity:
+            start_ptr = self.final_waypoints_start_ptr
+            final_end_ptr = self.final_waypoints_start_ptr + self.lookahead_wps
+            for ptr in range(start_ptr, final_end_ptr):
+                mod_ptr = ptr % len(self.waypoints)
+                self.waypoints[mod_ptr].twist.twist.linear.x = \
+                    self.default_velocity
+                # end for
+            # end if
+        # maybe this should be called from main loop
 
     def obstacle_cb(self, msg):
         # TODO: Callback for /obstacle_waypoint message.
@@ -162,19 +272,21 @@ class WaypointUpdater(object):
                       " end_wps_ptr = %d", start_wps_ptr, end_wps_ptr)
         if end_wps_ptr > start_wps_ptr:
             for w_p in self.waypoints[start_wps_ptr:end_wps_ptr]:
-                w_p.twist.twist.linear.x = self.default_velocity
+                # w_p.twist.twist.linear.x = self.default_velocity
                 new_wps_list.append(w_p)
             # end of for
         else:
             for w_p in self.waypoints[start_wps_ptr:]:
-                w_p.twist.twist.linear.x = self.default_velocity
+                # w_p.twist.twist.linear.x = self.default_velocity
                 new_wps_list.append(w_p)
             # end of for
             for w_p in self.waypoints[:end_wps_ptr]:
-                w_p.twist.twist.linear.x = self.default_velocity
+                # w_p.twist.twist.linear.x = self.default_velocity
                 new_wps_list.append(w_p)
             # end of for
         # end of if
+        # for now this should work, as no deepcopy. lets see
+        self.set_waypoints_velocity()
         rospy.loginfo("waypoint_updater:send_waypoints final_waypoints list"
                       " length is %d", len(new_wps_list))
         lane = Lane()
@@ -223,8 +335,11 @@ class WaypointUpdater(object):
                                 dist = tmpdist
                                 self.back_search = True
                             else:
-                                self.last_search_distance = dist
-                                return ((j+1) % len(self.waypoints))
+                                if abs(dist-self.last_search_distance) < 5.0:
+                                    self.last_search_distance = dist
+                                    return ((j+1) % len(self.waypoints))
+                                else:
+                                    break
                             # end if else
                         # end for
                     # end if
@@ -255,6 +370,7 @@ class WaypointUpdater(object):
         # Note: the first waypoint is closest to the car, not necessarily in
         # front of it.  Waypoint follower is responsible for finding this
 
+    # Todo need to adjust for looping
     def distance(self, wp1, wp2):
         dist = 0
 


### PR DESCRIPTION
For testing, I added a new dynamic parameter defaulting to the second set of traffic lights (wp = 759) that can be adjusted to allow car to move again after reaching stopline.  The car deceleration just uses linear deceleration at present, and then velocity is cut to 0 when velocity goes below a threshold, and when distance is within a radius of the stopline.  nothing is done for acceleration at present. Towards Issue #6 

Next pass is to use better logic to determine when deceleration should begin, (now I am just using number of waypoints away), and to use JMT to generate velocities.  

Also need to deepcopy waypoints from base_waypoints so that velocities placed by waypoint_loader (which are maximum velocities at that waypoint) do not get overwritten.  A global maximum velocity is currently being extracted from the waypoints, but need to check against each waypoint velocity.