### PR TITLE
Set message timestamps for statistics, disable obstacle msg (unused)

### DIFF
--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <launch>
+    <!-- Enable message timing statistics for rqt_graph analysis -->
+    <rosparam param="enable_statistics">true</rosparam>
+
     <!-- Simulator Bridge -->
     <include file="$(find styx)/launch/server.launch" />
 

--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -10,7 +10,7 @@ from sensor_msgs.msg import PointCloud2
 from sensor_msgs.msg import Image
 import sensor_msgs.point_cloud2 as pcl2
 from std_msgs.msg import Header
-from cv_bridge import CvBridge, CvBridgeError
+from cv_bridge import CvBridge  # , CvBridgeError
 
 from styx_msgs.msg import TrafficLight, TrafficLightArray, Lane
 import numpy as np
@@ -32,7 +32,7 @@ TYPE = {
     'brake_cmd': BrakeCmd,
     'throttle_cmd': ThrottleCmd,
     'path_draw': Lane,
-    'image':Image
+    'image': Image
 }
 
 
@@ -49,13 +49,15 @@ class Bridge(object):
             '/vehicle/steering_cmd': self.callback_steering,
             '/vehicle/throttle_cmd': self.callback_throttle,
             '/vehicle/brake_cmd': self.callback_brake,
-        '/final_waypoints': self.callback_path
+            '/final_waypoints': self.callback_path
         }
 
-        self.subscribers = [rospy.Subscriber(e.topic, TYPE[e.type], self.callbacks[e.topic])
+        self.subscribers = [rospy.Subscriber(e.topic, TYPE[e.type],
+                                             self.callbacks[e.topic])
                             for e in conf.subscribers]
 
-        self.publishers = {e.name: rospy.Publisher(e.topic, TYPE[e.type], queue_size=1)
+        self.publishers = {e.name: rospy.Publisher(e.topic, TYPE[e.type],
+                                                   queue_size=1)
                            for e in conf.publishers}
 
     def create_light(self, x, y, z, yaw, state):
@@ -81,7 +83,7 @@ class Bridge(object):
         pose.pose.position.y = y
         pose.pose.position.z = z
 
-        q = tf.transformations.quaternion_from_euler(0., 0., math.pi * yaw/180.)
+        q = tf.transformations.quaternion_from_euler(0., 0., math.pi*yaw/180.)
         pose.pose.orientation = Quaternion(*q)
 
         return pose
@@ -93,6 +95,10 @@ class Bridge(object):
 
     def create_twist(self, velocity, angular):
         tw = TwistStamped()
+        header = Header()
+        header.stamp = rospy.Time.now()
+        header.frame_id = '/world'
+        tw.header = header
         tw.twist.linear.x = velocity
         tw.twist.angular.z = angular
         return tw
@@ -122,26 +128,28 @@ class Bridge(object):
     def broadcast_transform(self, name, position, orientation):
         br = tf.TransformBroadcaster()
         br.sendTransform(position,
-            orientation,
-            rospy.Time.now(),
-            name,
-            "world")
+                         orientation,
+                         rospy.Time.now(),
+                         name,
+                         "world")
 
     def publish_odometry(self, data):
         pose = self.create_pose(data['x'], data['y'], data['z'], data['yaw'])
 
         position = (data['x'], data['y'], data['z'])
-        orientation = tf.transformations.quaternion_from_euler(0, 0, math.pi * data['yaw']/180.)
+        orientation = tf.transformations.quaternion_from_euler(
+                                              0, 0, math.pi * data['yaw']/180.)
         self.broadcast_transform("base_link", position, orientation)
 
         self.publishers['current_pose'].publish(pose)
-        self.vel = data['velocity']* 0.44704
+        self.vel = data['velocity'] * 0.44704
         self.angular = self.calc_angular(data['yaw'] * math.pi/180.)
-        self.publishers['current_velocity'].publish(self.create_twist(self.vel, self.angular))
-
+        self.publishers['current_velocity'].publish(
+                                     self.create_twist(self.vel, self.angular))
 
     def publish_controls(self, data):
-        steering, throttle, brake = data['steering_angle'], data['throttle'], data['brake']
+        steering, throttle, brake = data['steering_angle'], data['throttle'], \
+                                    data['brake']
         self.publishers['steering_report'].publish(self.create_steer(steering))
         self.publishers['throttle_report'].publish(self.create_float(throttle))
         self.publishers['brake_report'].publish(self.create_float(brake))
@@ -157,18 +165,22 @@ class Bridge(object):
         self.publishers['obstacle_points'].publish(cloud)
 
     def publish_lidar(self, data):
-        self.publishers['lidar'].publish(self.create_point_cloud_message(zip(data['lidar_x'], data['lidar_y'], data['lidar_z'])))
+        self.publishers['lidar'].publish(self.create_point_cloud_message(
+                       zip(data['lidar_x'], data['lidar_y'], data['lidar_z'])))
 
     def publish_traffic(self, data):
-        x, y, z = data['light_pos_x'], data['light_pos_y'], data['light_pos_z'],
-        yaw = [math.atan2(dy, dx) for dx, dy in zip(data['light_pos_dx'], data['light_pos_dy'])]
+        x, y, z = data['light_pos_x'], data['light_pos_y'], data['light_pos_z']
+        yaw = [math.atan2(dy, dx) for dx, dy in zip(data['light_pos_dx'],
+                                                    data['light_pos_dy'])]
         status = data['light_state']
 
         lights = TrafficLightArray()
         header = Header()
         header.stamp = rospy.Time.now()
         header.frame_id = '/world'
-        lights.lights = [self.create_light(*e) for e in zip(x, y, z, yaw, status)]
+        lights.header = header
+        lights.lights = [self.create_light(*e) for e in zip(x, y, z, yaw,
+                                                            status)]
         self.publishers['trafficlights'].publish(lights)
 
     def publish_dbw_status(self, data):
@@ -180,10 +192,15 @@ class Bridge(object):
         image_array = np.asarray(image)
 
         image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="rgb8")
+        header = Header()
+        header.stamp = rospy.Time.now()
+        header.frame_id = '/world'
+        image_message.header = header
         self.publishers['image'].publish(image_message)
 
     def callback_steering(self, data):
-        self.server('steer', data={'steering_angle': str(data.steering_wheel_angle_cmd)})
+        self.server('steer', data={'steering_angle':
+                                   str(data.steering_wheel_angle_cmd)})
 
     def callback_throttle(self, data):
         self.server('throttle', data={'throttle': str(data.pedal_cmd)})

--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -10,7 +10,7 @@ from sensor_msgs.msg import PointCloud2
 from sensor_msgs.msg import Image
 import sensor_msgs.point_cloud2 as pcl2
 from std_msgs.msg import Header
-from cv_bridge import CvBridge  # , CvBridgeError
+from cv_bridge import CvBridge
 
 from styx_msgs.msg import TrafficLight, TrafficLightArray, Lane
 import numpy as np
@@ -220,4 +220,5 @@ class Bridge(object):
             y_values.append(y)
             z_values.append(z)
 
-        self.server('drawline', data={'next_x': x_values, 'next_y': y_values, 'next_z': z_values})
+        self.server('drawline', data={'next_x': x_values, 'next_y': y_values,
+                                      'next_z': z_values})

--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -6,7 +6,7 @@ eventlet.monkey_patch(socket=True, select=True, time=True)
 import eventlet.wsgi
 import socketio
 import time
-from flask import Flask, render_template
+from flask import Flask  # , render_template
 
 from bridge import Bridge
 from conf import conf
@@ -26,17 +26,21 @@ msgs = {}
 
 dbw_enable = False
 
+
 @sio.on('connect')
 def connect(sid, environ):
     print("connect ", sid)
 
+
 def send(topic, data):
-    s = 1
+    #s = 1
     #msgs.append((topic, data))
     msgs[topic] = data
     #sio.emit(topic, data=json.dumps(data), skip_sid=True)
 
+
 bridge = Bridge(conf, send)
+
 
 @sio.on('telemetry')
 def telemetry(sid, data):
@@ -50,25 +54,35 @@ def telemetry(sid, data):
         topic, data = msgs.popitem()
         sio.emit(topic, data=data, skip_sid=True)
 
+
 @sio.on('control')
 def control(sid, data):
     bridge.publish_controls(data)
 
+
 @sio.on('obstacle')
 def obstacle(sid, data):
-    bridge.publish_obstacles(data)
+    # Disable publishing obstacle data because these are publishing at high
+    # frequency and are not used for anything
+
+    # bridge.publish_obstacles(data)
+    pass
+
 
 @sio.on('lidar')
 def obstacle(sid, data):
     bridge.publish_lidar(data)
 
+
 @sio.on('trafficlights')
 def trafficlights(sid, data):
     bridge.publish_traffic(data)
 
+
 @sio.on('image')
 def image(sid, data):
     bridge.publish_camera(data)
+
 
 if __name__ == '__main__':
 

--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -5,8 +5,7 @@ eventlet.monkey_patch(socket=True, select=True, time=True)
 
 import eventlet.wsgi
 import socketio
-import time
-from flask import Flask  # , render_template
+from flask import Flask
 
 from bridge import Bridge
 from conf import conf
@@ -21,7 +20,6 @@ https://github.com/amakurin/CarND-Capstone/commit/9809bc60d51c06174f8c8bfe6c40c8
 
 sio = socketio.Server()
 app = Flask(__name__)
-#msgs = []
 msgs = {}
 
 dbw_enable = False
@@ -33,10 +31,7 @@ def connect(sid, environ):
 
 
 def send(topic, data):
-    #s = 1
-    #msgs.append((topic, data))
     msgs[topic] = data
-    #sio.emit(topic, data=json.dumps(data), skip_sid=True)
 
 
 bridge = Bridge(conf, send)
@@ -50,7 +45,6 @@ def telemetry(sid, data):
         bridge.publish_dbw_status(dbw_enable)
     bridge.publish_odometry(data)
     for i in range(len(msgs)):
-        #topic, data = msgs.pop(0)
         topic, data = msgs.popitem()
         sio.emit(topic, data=data, skip_sid=True)
 

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -87,18 +87,25 @@ class DBWNode(object):
             rate.sleep()
 
     def publish(self, throttle, brake, steer):
+        header = Header()
+        header.stamp = rospy.Time.now()
+        header.frame_id = '/world'
+
         tcmd = ThrottleCmd()
+        tcmd.header = header
         tcmd.enable = True
         tcmd.pedal_cmd_type = ThrottleCmd.CMD_PERCENT
         tcmd.pedal_cmd = throttle
         self.throttle_pub.publish(tcmd)
 
         scmd = SteeringCmd()
+        scmd.header = header
         scmd.enable = True
         scmd.steering_wheel_angle_cmd = steer
         self.steer_pub.publish(scmd)
 
         bcmd = BrakeCmd()
+        bcmd.header = header
         bcmd.enable = True
         bcmd.pedal_cmd_type = BrakeCmd.CMD_TORQUE
         bcmd.pedal_cmd = brake

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -292,7 +292,7 @@ class WaypointUpdater(object):
         lane = Lane()
         lane.waypoints = list(new_wps_list)
         lane.header.frame_id = '/world'
-        lane.header.stamp = rospy.Time()
+        lane.header.stamp = rospy.Time.now()
         self.pubs['/final_waypoints'].publish(lane)
         self.final_waypoints = list(new_wps_list)
         self.final_waypoints_start_ptr = start_wps_ptr


### PR DESCRIPTION
With timestamps set on each message, we can now analyze communication timing statistics in *rqt_graph*.

Also, disable publishing obstacle data messages because they are coming from the simulator at high frequency and are not used for anything.