### PR TITLE
Allow dynamic reconfiguration of velocity PID control parameters

### DIFF
--- a/ros/src/twist_controller/CMakeLists.txt
+++ b/ros/src/twist_controller/CMakeLists.txt
@@ -9,6 +9,7 @@ project(twist_controller)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dbw_mkz_msgs
+  dynamic_reconfigure
   geometry_msgs
   roscpp
   rospy
@@ -91,10 +92,9 @@ find_package(catkin REQUIRED COMPONENTS
 ##     and list every .cfg file to be processed
 
 ## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
+generate_dynamic_reconfigure_options(
+   cfg/DynReconf.cfg
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/twist_controller/cfg/DynReconf.cfg
+++ b/ros/src/twist_controller/cfg/DynReconf.cfg
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# set up dynamically reconfigurable parameters here
+
+from dynamic_reconfigure.parameter_generator_catkin import \
+            ParameterGenerator, double_t
+
+PACKAGE = "twist_controller"
+
+gen = ParameterGenerator()
+
+gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.1, 0, 2)
+gen.add("dyn_velo_integral_control", double_t, 0, "Velocity integral control constant", 0.000005, 0, 0.1)
+gen.add("dyn_velo_differential_control", double_t, 0, "Velocity integral control constant", 0.05, 0, 1)
+
+exit(gen.generate(PACKAGE, "twist_controller", "DynReconf"))

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -6,7 +6,7 @@ from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 from geometry_msgs.msg import TwistStamped
 import math
 
-from twist_controller import Controller
+from twist_controller_mod import Controller
 
 
 '''

--- a/ros/src/twist_controller/package.xml
+++ b/ros/src/twist_controller/package.xml
@@ -41,11 +41,13 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>dbw_mkz_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <run_depend>dbw_mkz_msgs</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
For #4 - PID control parameters are now dynamically reconfigurable. Other parameters can be added at a later date if desired.

I've verified that these changes run properly in the simulator, and I can change the characteristics of the throttle and braking profile dynamically at runtime.