### PR TITLE
JMT based waypoint_updater - broken implementation

### DIFF
--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -6,13 +6,16 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+# 759
 gen.add("dyn_test_stoplight_wp",   int_t, 0, "TESTING next stopline wp",
-        759, 0, 11010)
+        470, 0, 10902)
 gen.add("dyn_update_rate",         int_t, 0, "An Integer parameter",
         10, 1, 50)
 gen.add("dyn_lookahead_wps",       int_t, 0, "number of final waypoints",
-        200, 10,  500)
+        50, 10,  200)
 gen.add("dyn_default_velocity", double_t, 0, "speed to use",
         20.0, 0.0, 100.0)
+gen.add("dyn_default_accel",    double_t, 0, "maximum accel deccel to use",
+        1.2, 0.0, 10.0)
 
 exit(gen.generate(PACKAGE, "waypoint_updater", "DynReconf"))

--- a/ros/src/waypoint_updater/trajectorytest.py
+++ b/ros/src/waypoint_updater/trajectorytest.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python
+import math
+import numpy as np
+
+
+def main():
+    test = traj()
+    test.load_waypoints()
+    test.set_location(20)
+    test.generate_trajectory()
+
+
+def get_accel_distance(Vi, Vf, A):
+    return (Vf**2 - Vi**2)/(2.0 * A)
+
+
+def get_accel_time(S, Vi, Vf):
+    return(2.0 * S / (Vi + Vf))
+
+
+class JMT(object):
+    def __init__(self, start, end, T):
+        """
+        Calculates Jerk Minimizing Trajectory for start, end and T.
+        start and end include
+        [displacement, velocity, acceleration]
+        """
+        self.start = start
+        self.end = end
+        self.final_displacement = end[0]
+        self.T = T
+
+        a_0, a_1, a_2 = start[0], start[1], start[2] / 2.0
+        c_0 = a_0 + a_1 * T + a_2 * T**2
+        c_1 = a_1 + 2 * a_2 * T
+        c_2 = 2 * a_2
+
+        A = np.array([
+                     [T**3,   T**4,    T**5],
+                     [3*T**2, 4*T**3,  5*T**4],
+                     [6*T,   12*T**2, 20*T**3],
+                     ])
+
+        B = np.array([
+                     end[0] - c_0,
+                     end[1] - c_1,
+                     end[2] - c_2
+                     ])
+        a_3_4_5 = np.linalg.solve(A, B)
+        self.coeffs = np.concatenate([np.array([a_0, a_1, a_2]), a_3_4_5])
+
+    # def JMTD_at(self, displacement, coeffs, t0, tmax, deq_wpt_ptr):
+    def JMTD_at(self, displacement, t0, tmax):
+        # find JMT descriptors at displacement
+        s_last = 0.0
+        t_found = False
+        t_inc = 0.005
+
+        for t_cnt in range(int((tmax-t0)/t_inc) + 1000):
+
+            t = t0 + t_cnt * t_inc
+            s = self.coeffs[0] + self.coeffs[1]*t + self.coeffs[2]*t*t + self.coeffs[3]*t*t*t +\
+                self.coeffs[4]*t*t*t*t + self.coeffs[5]*t*t*t*t*t
+            if s > displacement:
+                t = t - (1 - (s - displacement) / (s - s_last)) * t_inc
+                t_found = True
+                break
+            # end if
+            s_last = s
+        # end for
+        if t_found is False:
+            print("waypoint_updater:JMTDat Ran out of bounds without "
+                         "finding target displacement")
+            return None
+
+        t2 = t*t
+        t3 = t2*t
+        t4 = t3*t
+        t5 = t4*t
+
+        s = self.coeffs[0] + self.coeffs[1]*t + self.coeffs[2]*t2 + self.coeffs[3]*t3 +\
+            self.coeffs[4]*t4 + self.coeffs[5]*t5
+        v = self.coeffs[1] + 2*self.coeffs[2]*t +\
+            3*self.coeffs[3]*t2 + 4*self.coeffs[4]*t3 + 5*self.coeffs[5]*t4
+        a = 2*self.coeffs[2] + 6*self.coeffs[3]*t + 12*self.coeffs[4]*t2 +\
+            20*self.coeffs[5]*t3
+        j = 6*self.coeffs[3] + 24*self.coeffs[4]*t + 60*self.coeffs[5]*t2
+
+        delta_s = (displacement - s)
+        if delta_s > 0.1:
+            print("waypoint_updater:JMTD_at need to refine algo,"
+                          " delta_s is {}".format(delta_s))
+
+        
+        details = JMTDetails(s,v,a,j,t)
+
+        print ("waypoint_updater:JMTD_at displacement {} found s,v,a,j,t = {}".format(displacement, details))
+
+        return details
+
+
+class pose(object):
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class JMTDetails(object):
+    def __init__(self, S, V, A, J, t):
+        self.S = S
+        self.V = V
+        self.A = A
+        self.J = J
+        self.time = t
+
+    def set_VAJt(self, V, A, J, time):
+        self.V = V
+        self.A = A
+        self.J = J
+        self.time = time
+
+    def __repr__(self):
+        return "%5.3f, %2.4f, %2.4f, %2.4f, %2.3f" % (self.S, self.V, self.A, self.J, self.time)
+
+
+class waypoint(object):
+    def __init__(self, xval, yval, zval, max_v, ptr_id, s):
+        self.position = pose(xval, yval, zval)
+        self.v = max_v
+        self.JMTD = JMTDetails(s,0.0,0.0,0.0,0.0)
+        self.ptr_id = ptr_id
+        self.state = None
+        self.JMT_ptr = -1 # points to JMT object
+
+
+class traj(object):
+    def __init__(self):
+
+        # set up variables
+        self.waypoints = []
+        # pointer to location in waypoints that final waypoints begins at
+        self.final_waypoints_start_ptr = -1
+        # closest waypoint used on last iteration when sending final waypoints
+        self.last_waypoint = None
+        #
+        self.max_velocity = 11.1
+        # default velocity is a dynamically adjustable target velocity
+        self.default_velocity = 11.0
+        self.max_A = 9.0
+        self.max_V = 11.1
+        self.max_J = 9.0
+        # target max acceleration/braking force - dynamically adjustable
+        self.default_accel = 1.5
+        # are we in a deceleration phase
+        self.slow_down = False
+        # store details of JMT phases in a list
+        self.JMT_List = []
+        # store jerk minimizing Trajectory coefficients here
+        self.JMTcoeffs = None
+        # where did velocity change start
+        # self.JMT_start_ptr = -1
+        # self.JMT_time = 0.0
+        # self.JMT_max_time = 0.0
+        # modes of operation
+        self.states = ['stopped', 'startspeedup', 'JMTspeedup',
+                       'maintainspeed', 'JMTslowdown']
+        self.state = self.states[0]
+
+        self.initiate_waypoints()
+
+    def load_waypoints(self):
+        cntr = 0
+        s = 0.0
+        for pt in self.raw_waypoints:
+            
+            if cntr > 0:
+                # won't come into here until after wpt loaded
+                # in previous loop
+                s += math.sqrt((wpt.position.x-pt[0])**2 +
+                               (wpt.position.y-pt[1])**2)
+
+            wpt = waypoint(pt[0],pt[1],pt[2],pt[3],cntr,s)
+            self.waypoints.append(wpt)
+            cntr += 1
+            
+        print "Loaded {} waypoints".format(len(self.waypoints))
+
+    def set_location(self, ptr_id):
+        self.final_waypoints_start_ptr = ptr_id
+
+    def generate_trajectory(self):
+        ptr = self.final_waypoints_start_ptr
+        curpt = self.waypoints[ptr]
+        curpt.JMTD.V = 1.5
+        curpt.JMTD.A = self.default_accel
+
+        target_velocity = self.max_velocity * 0.9
+
+        jmt_ptr = self.setup_jmt(curpt, target_velocity)
+
+        curpt.JMT_ptr = jmt_ptr
+        JMT_instance = self.JMT_List[jmt_ptr]
+
+        t = 0.0
+        last_wpt = ptr+1
+        recalc = False
+        for wpt in self.waypoints[ptr+1:]:
+            last_wpt = wpt.ptr_id
+            if wpt.JMTD.S > JMT_instance.final_displacement:
+                print "Passed beyond S = {} at ptr_id = {}".format(JMT_instance.final_displacement, last_wpt)
+                break
+            jmt_point = JMT_instance.JMTD_at(wpt.JMTD.S, t, JMT_instance.T*1.5)
+            if jmt_point is None:
+                print "JMT_at returned None at ptr_id = {}".format(last_wpt)
+                break
+
+            wpt.JMTD.set_VAJt(jmt_point.V, jmt_point.A, jmt_point.J, jmt_point.time)
+            
+            if jmt_point.A > self.max_A:
+                print "A of {} exceeds max value of {} at ptr = {}".format(jmt_point.A, self.max_A, wpt.ptr_id)
+                recalc = True
+            if jmt_point.J > self.max_J:
+                print "J of {} exceeds max value of {} at ptr = {}".format(jmt_point.J, self.max_J, wpt.ptr_id)
+                recalc = True
+            if jmt_point.V > self.max_V:
+                print "V of {} exceeds max value of {} at ptr = {}".format(jmt_point.V, self.max_V, wpt.ptr_id)
+                recalc = True
+        print "ptr_id, S, V, A, J, time"
+        for wpt in self.waypoints[ptr:last_wpt]:
+            print "{}, {}".format(wpt.ptr_id, wpt.JMTD)
+
+        print "recalc is set to {} ".format(recalc)
+
+
+    def setup_jmt(self, curpt, target_velocity):
+
+        a_dist = get_accel_distance(curpt.JMTD.V, target_velocity, self.default_accel)
+        T = get_accel_time(a_dist, curpt.JMTD.V, target_velocity)
+
+        print "Setup JMT to accelerate to {} by distance {} in time {}".format(target_velocity, a_dist, T)
+
+        start = [curpt.JMTD.S, curpt.JMTD.V, curpt.JMTD.A]
+        end = [curpt.JMTD.S + a_dist, target_velocity, 0.0]
+        jmt = JMT(start, end, T)
+        self.JMT_List.append(jmt)
+        jmt_ptr = len(self.JMT_List)
+
+        return jmt_ptr-1
+
+
+    def distance(self, wp1, wp2):
+        # TODO need to adjust for looping or reverse
+        dist = 0
+        if wp1 == wp2:
+            return 0.0
+
+        def distance_lambda(a, b): return math.sqrt((a.x-b.x)**2 +
+                                                    (a.y-b.y)**2 +
+                                                    (a.z-b.z)**2)
+        for i in range(wp1, wp2+1):
+            dist += distance_lambda(self.waypoints[wp1].position,
+                                    self.waypoints[i].position)
+            # dist += distance_lambda(self.waypoints[wp1].pose.pose.position,
+            #                         self.waypoints[i].pose.pose.position)
+            wp1 = i
+        return dist
+
+    def get_stopping_distance(self, velocity):
+        # reasonable guess of distance needed to stop at speed and
+        # max decceleration rate
+
+        safety_factor = 1.2  # this should be much smaller with braking
+        distance_needed = velocity * velocity / (2.0 * self.default_accel)
+        distance_needed *= safety_factor
+        # if distance_needed > 0.0 and distance_needed < 75.0:
+        #    rospy.loginfo("Stopping Distance Needed is {}".
+        #                  format(distance_needed))
+        return distance_needed
+
+
+
+    def initiate_waypoints(self):
+        self.raw_waypoints = [[1116.28,1181.84,0.0,11.1],
+            [1117.15,1181.95,0.0,11.1],
+            [1118.03,1182.07,0.0,11.1],
+            [1118.9,1182.18,0.0,11.1],
+            [1119.78,1182.29,0.0,11.1],
+            [1120.22,1182.35,0.0,11.1],
+            [1121.1,1182.45,0.0,11.1],
+            [1121.97,1182.55,0.0,11.1],
+            [1122.85,1182.65,0.0,11.1],
+            [1123.73,1182.75,0.0,11.1],
+            [1124.6,1182.84,0.0,11.1],
+            [1125.04,1182.89,0.0,11.1],
+            [1125.92,1182.98,0.0,11.1],
+            [1126.8,1183.07,0.0,11.1],
+            [1127.68,1183.16,0.0,11.1],
+            [1128.56,1183.24,0.0,11.1],
+            [1129.44,1183.33,0.0,11.1],
+            [1129.88,1183.37,0.0,11.1],
+            [1130.76,1183.45,0.0,11.1],
+            [1131.64,1183.53,0.0,11.1],
+            [1132.52,1183.6,0.0,11.1],
+            [1133.4,1183.68,0.0,11.1],
+            [1134.28,1183.75,0.0,11.1],
+            [1135.16,1183.82,0.0,11.1],
+            [1136.04,1183.89,0.0,11.1],
+            [1136.48,1183.93,0.0,11.1],
+            [1137.37,1184,0.0,11.1],
+            [1138.25,1184.07,0.0,11.1],
+            [1139.13,1184.13,0.0,11.1],
+            [1140.02,1184.19,0.0,11.1],
+            [1140.9,1184.26,0.0,11.1],
+            [1141.78,1184.32,0.0,11.1],
+            [1142.66,1184.38,0.0,11.1],
+            [1143.1,1184.41,0.0,11.1],
+            [1143.98,1184.47,0.0,11.1],
+            [1144.86,1184.54,0.0,11.1],
+            [1145.74,1184.6,0.0,11.1],
+            [1146.63,1184.66,0.0,11.1],
+            [1147.51,1184.72,0.0,11.1],
+            [1148.39,1184.78,0.0,11.1],
+            [1149.28,1184.84,0.0,11.1],
+            [1150.16,1184.89,0.0,11.1],
+            [1151.04,1184.95,0.0,11.1],
+            [1151.48,1184.98,0.0,11.1],
+            [1152.36,1185.03,0.0,11.1],
+            [1153.24,1185.09,0.0,11.1],
+            [1154.12,1185.14,0.0,11.1],
+            [1155.01,1185.19,0.0,11.1],
+            [1155.89,1185.24,0.0,11.1],
+            [1156.77,1185.29,0.0,11.1],
+            [1157.65,1185.34,0.0,11.1],
+            [1158.53,1185.39,0.0,11.1],
+            [1159.41,1185.44,0.0,11.1],
+            [1160.3,1185.49,0.0,11.1],
+            [1161.18,1185.54,0.0,11.1],
+            [1162.06,1185.59,0.0,11.1],
+            [1162.94,1185.64,0.0,11.1],
+            [1163.83,1185.69,0.0,11.1],
+            [1164.71,1185.73,0.0,11.1],
+            [1166.03,1185.81,0.0,11.1],
+            [1166.91,1185.86,0.0,11.1],
+            [1167.79,1185.9,0.0,11.1],
+            [1168.67,1185.95,0.0,11.1],
+            [1169.56,1186,0.0,11.1],
+            [1170.44,1186.05,0.0,11.1],
+            [1171.32,1186.1,0.0,11.1],
+            [1172.2,1186.14,0.0,11.1],
+            [1173.08,1186.19,0.0,11.1],
+            [1173.96,1186.24,0.0,11.1],
+            [1175.29,1186.31,0.0,11.1],
+            [1176.17,1186.36,0.0,11.1],
+            [1177.05,1186.41,0.0,11.1],
+            [1177.94,1186.45,0.0,11.1],
+            [1178.82,1186.5,0.0,11.1],
+            [1179.7,1186.54,0.0,11.1],
+            [1180.59,1186.59,0.0,11.1],
+            [1181.91,1186.66,0.0,11.1],
+            [1182.79,1186.7,0.0,11.1],
+            [1183.68,1186.75,0.0,11.1],
+            [1184.56,1186.8,0.0,11.1],
+            [1185.88,1186.87,0.0,11.1],
+            [1186.77,1186.91,0.0,11.1],
+            [1187.65,1186.96,0.0,11.1],
+            [1188.98,1187.02,0.0,11.1],
+            [1189.86,1187.07,0.0,11.1],
+            [1190.75,1187.11,0.0,11.1],
+            [1192.07,1187.18,0.0,11.1],
+            [1192.96,1187.22,0.0,11.1],
+            [1193.84,1187.27,0.0,11.1],
+            [1195.17,1187.33,0.0,11.1],
+            [1196.06,1187.38,0.0,11.1],
+            [1196.94,1187.42,0.0,11.1],
+            [1198.27,1187.49,0.0,11.1],
+            [1199.15,1187.53,0.0,11.1],
+            [1200.03,1187.57,0.0,11.1],
+            [1201.36,1187.64,0.0,11.1],
+            [1202.24,1187.68,0.0,11.1],
+            [1203.57,1187.75,0.0,11.1],
+            [1204.45,1187.79,0.0,11.1],
+            [1205.78,1187.86,0.0,11.1],
+            [1206.66,1187.9,0.0,11.1],
+            [1207.99,1187.96,0.0,11.1],
+            [1208.87,1188,0.0,11.1],
+            [1210.19,1188.06,0.0,11.1],
+            [1211.08,1188.1,0.0,11.1],
+            [1212.4,1188.16,0.0,11.1],
+            [1213.29,1188.19,0.0,11.1],
+            [1214.62,1188.24,0.0,11.1],
+            [1215.5,1188.28,0.0,11.1],
+            [1216.83,1188.32,0.0,11.1],
+            [1217.71,1188.35,0.0,11.1],
+            [1219.04,1188.38,0.0,11.1],
+            [1219.92,1188.41,0.0,11.1],
+            [1221.24,1188.44,0.0,11.1],
+            [1222.13,1188.46,0.0,11.1],
+            [1223.45,1188.48,0.0,11.1],
+            [1224.34,1188.5,0.0,11.1],
+            [1225.66,1188.52,0.0,11.1],
+            [1226.55,1188.53,0.0,11.1],
+            [1227.87,1188.54,0.0,11.1],
+            [1228.76,1188.54,0.0,11.1],
+            [1230.09,1188.55,0.0,11.1],
+            [1231.41,1188.55,0.0,11.1],
+            [1232.29,1188.54,0.0,11.1],
+            [1233.62,1188.54,0.0,11.1],
+            [1234.5,1188.53,0.0,11.1],
+            [1235.83,1188.52,0.0,11.1],
+            [1236.71,1188.51,0.0,11.1],
+            [1238.04,1188.5,0.0,11.1],
+            [1238.92,1188.49,0.0,11.1],
+            [1240.25,1188.47,0.0,11.1],
+            [1241.13,1188.46,0.0,11.1],
+            [1242.46,1188.44,0.0,11.1],
+            [1243.34,1188.42,0.0,11.1],
+            [1244.67,1188.4,0.0,11.1],
+            [1245.55,1188.38,0.0,11.1],
+            [1246.88,1188.36,0.0,11.1],
+            [1247.76,1188.34,0.0,11.1],
+            [1249.09,1188.31,0.0,11.1],
+            [1249.97,1188.29,0.0,11.1],
+            [1251.29,1188.26,0.0,11.1],
+            [1252.18,1188.23,0.0,11.1],
+            [1253.5,1188.2,0.0,11.1],
+            [1254.39,1188.17,0.0,11.1],
+            [1255.72,1188.13,0.0,11.1],
+            [1256.6,1188.1,0.0,11.1],
+            [1257.92,1188.06,0.0,11.1],
+            [1258.81,1188.03,0.0,11.1],
+            [1260.13,1187.99,0.0,11.1],
+            [1261.02,1187.96,0.0,11.1],
+            [1262.34,1187.92,0.0,11.1],
+            [1263.23,1187.89,0.0,11.1],
+            [1264.56,1187.85,0.0,11.1],
+            [1265.44,1187.82,0.0,11.1],
+            [1266.76,1187.78,0.0,11.1],
+            [1268.09,1187.74,0.0,11.1],
+            [1268.97,1187.71,0.0,11.1],
+            [1270.3,1187.67,0.0,11.1],
+            [1271.18,1187.64,0.0,11.1],
+            [1272.51,1187.6,0.0,11.1],
+            [1273.83,1187.56,0.0,11.1],
+            [1275.16,1187.51,0.0,11.1],
+            [1276.04,1187.49,0.0,11.1],
+            [1277.37,1187.44,0.0,11.1],
+            [1278.69,1187.4,0.0,11.1],
+            [1279.58,1187.38,0.0,11.1],
+            [1280.9,1187.34,0.0,11.1],
+            [1282.23,1187.29,0.0,11.1],
+            [1283.12,1187.27,0.0,11.1],
+            [1284.44,1187.22,0.0,11.1],
+            [1285.76,1187.17,0.0,11.1],
+            [1286.65,1187.13,0.0,11.1],
+            [1287.97,1187.07,0.0,11.1],
+            [1289.3,1187.01,0.0,11.1],
+            [1290.18,1186.96,0.0,11.1],
+            [1291.5,1186.89,0.0,11.1],
+            [1292.38,1186.84,0.0,11.1],
+            [1293.71,1186.76,0.0,11.1],
+            [1295.03,1186.68,0.0,11.1],
+            [1295.91,1186.62,0.0,11.1],
+            [1297.23,1186.52,0.0,11.1],
+            [1298.11,1186.46,0.0,11.1],
+            [1299,1186.4,0.0,11.1],
+            [1300.32,1186.3,0.0,11.1],
+            [1301.2,1186.23,0.0,11.1],
+            [1302.53,1186.12,0.0,11.1],
+            [1303.41,1186.05,0.0,11.1],
+            [1304.29,1185.98,0.0,11.1],
+            [1305.17,1185.9,0.0,11.1],
+            [1306.49,1185.79,0.0,11.1],
+            [1307.37,1185.71,0.0,11.1],
+            [1308.25,1185.63,0.0,11.1],
+            [1309.13,1185.55,0.0,11.1],
+            [1310.01,1185.46,0.0,11.1],
+            [1311.33,1185.34,0.0,11.1],
+            [1312.21,1185.25,0.0,11.1],
+            [1313.09,1185.16,0.0,11.1],
+            [1313.96,1185.08,0.0,11.1],
+            [1314.84,1184.98,0.0,11.1],
+            [1315.72,1184.89,0.0,11.1],
+            [1316.6,1184.81,0.0,11.1],
+            [1317.48,1184.71,0.0,11.1],
+            [1318.37,1184.62,0.0,11.1],
+            [1319.25,1184.53,0.0,11.1],
+            [1319.68,1184.48,0.0,11.1],
+            [1320.56,1184.39,0.0,11.1],
+            [1321.44,1184.3,0.0,11.1],
+            [1322.32,1184.21,0.0,11.1],
+            [1323.2,1184.12,0.0,11.1],
+            [1324.08,1184.03,0.0,11.1],
+            [1324.96,1183.93,0.0,11.1],
+            [1325.84,1183.85,0.0,11.1],
+            [1326.72,1183.76,0.0,11.1],
+            [1327.6,1183.66,0.0,11.1],
+            [1328.48,1183.58,0.0,11.1],
+            [1329.36,1183.48,0.0,11.1],
+            [1329.8,1183.44,0.0,11.1],
+            [1330.68,1183.35,0.0,11.1],
+            [1331.56,1183.26,0.0,11.1],
+            [1332.44,1183.17,0.0,11.1],
+            [1333.32,1183.08,0.0,11.1],
+            [1334.2,1182.99,0.0,11.1],
+            [1335.08,1182.9,0.0,11.1],
+            [1335.96,1182.81,0.0,11.1],
+            [1336.84,1182.72,0.0,11.1],
+            [1337.72,1182.64,0.0,11.1],
+            [1338.16,1182.59,0.0,11.1],
+            [1339.04,1182.51,0.0,11.1],
+            [1339.91,1182.42,0.0,11.1],
+            [1340.79,1182.33,0.0,11.1],
+            [1341.67,1182.25,0.0,11.1],
+            [1342.55,1182.16,0.0,11.1],
+            [1343.43,1182.08,0.0,11.1],
+            [1344.32,1181.99,0.0,11.1],
+            [1345.2,1181.91,0.0,11.1],
+            [1346.08,1181.82,0.0,11.1],
+            [1346.52,1181.78,0.0,11.1],
+            [1347.4,1181.7,0.0,11.1],
+            [1348.28,1181.61,0.0,11.1],
+            [1349.16,1181.53,0.0,11.1],
+            [1350.04,1181.44,0.0,11.1],
+            [1350.92,1181.36,0.0,11.1],
+            [1351.8,1181.28,0.0,11.1],
+            [1352.68,1181.19,0.0,11.1],
+            [1353.56,1181.11,0.0,11.1],
+            [1354,1181.07,0.0,11.1],
+            [1354.88,1180.98,0.0,11.1],
+            [1355.76,1180.9,0.0,11.1],
+            [1356.64,1180.81,0.0,11.1],
+            [1357.52,1180.73,0.0,11.1],
+            [1358.4,1180.65,0.0,11.1],
+            [1359.28,1180.56,0.0,11.1],
+            [1359.71,1180.52,0.0,11.1],
+            [1360.6,1180.44,0.0,11.1],
+            [1361.48,1180.35,0.0,11.1],
+            [1362.36,1180.27,0.0,11.1],
+            [1363.24,1180.18,0.0,11.1],
+            [1364.12,1180.1,0.0,11.1],
+            [1364.56,1180.06,0.0,11.1]]
+
+
+
+if __name__ == '__main__':
+    main()

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -5,11 +5,16 @@
 
 import rospy
 import math
+import numpy as np
+import itertools
+
 import copy
+from collections import deque
 
 from geometry_msgs.msg import PoseStamped, TwistStamped
 from styx_msgs.msg import Lane, Waypoint, TrafficLightArray, TrafficLight
 from std_msgs.msg import String, Int32
+
 from dynamic_reconfigure.server import Server
 from waypoint_updater.cfg import DynReconfConfig
 
@@ -30,39 +35,102 @@ classifier.
 '''
 
 
+# object to store details of motion at waypoint
+class deq_waypoint(object):
+    def __init__(self, ptr_id, waypoint):
+        self.max_V = waypoint.twist.twist.linear.x
+        self.V = 0.0
+        self.A = 0.0
+        self.J = 0.0
+        self.waypoint = waypoint
+        self.waypoint.twist.twist.linear.x = 0.0
+        self.ptr_id = ptr_id
+        self.state = None
+        self.phase_start_ptr = 0  # initiate at ptr_id ?
+
+
 class WaypointUpdater(object):
     def __init__(self):
+        # set up variables
+
+        # check on whether dynamic parameters have been received yet
         self.dyn_vals_received = False
+        # list to hold waypoints from waypoint_loader
         self.waypoints = []
+        # current reported pose
         self.pose = None
+        # current reported velocity
         self.velocity = None
+        # to store traffic light data in if required
         self.lights = None
-        self.final_waypoints = []
-        self.final_waypoints_start_ptr = 0
+        # number of waypoints to send out - not sure how many are useful
+        self.lookahead_wps = 50  # 200
+        # set up deque
+        # have a backwards buffer
+        self.rear_buffer = 20
+        # set up max dequelen which will trigger right pops
+        self.max_dequelen = self.lookahead_wps + self.rear_buffer
+        # deque to hold final waypoints
+        self.f_wpdeq = deque(maxlen=self.max_dequelen)
+        # pointer to location in waypoints that final waypoints begins at
+        self.final_waypoints_start_ptr = -1
+        # closest waypoint used on last iteration when sending final waypoints
+        self.last_waypoint = None
+        # check to see if we found closest waypoint by looking backwards
         self.back_search = False
+        # measurement of distance to closest waypoint on last iteration
         self.last_search_distance = None
+        # time at which last closest_waypoint iteration occurred
         self.last_search_time = None
-        self.next_traffic_light_wp = None
+        # waypoint closest to next traffic light stop line when it is red
+        self.next_traffic_light_wp = -1  # was None
+        # speed to iterate next waypoint list
         self.update_rate = 10
+        # global max velocity - this will be found in waypoints
         self.max_velocity = 0.0
+        # default velocity is a dynamically adjustable target velocity
         self.default_velocity = 10.0
-        self.lookahead_wps = 200
+        # target max acceleration/braking force - dynamically adjustable
+        self.default_accel = 1.5
+        # are we in a deceleration phase
+        self.slow_down = False
+        # store jerk minimizing Trajectory coefficients here
+        self.JMTcoeffs = None
+        # where did velocity change start
+        self.JMT_start_ptr = -1
+        self.JMT_time = 0.0
+        self.JMT_max_time = 0.0
+        # dictionary of subscribers for this node
         self.subs = {}
+        # dictionary of publishers for this node
         self.pubs = {}
+        # dynamic reconfiguration server for this node
         self.dyn_reconf_srv = None
+        # modes of operation
+        self.states = ['stopped', 'startspeedup', 'JMTspeedup',
+                       'maintainspeed', 'JMTslowdown']
+        self.state = self.states[0]
+        # variables defined
 
         rospy.init_node('waypoint_updater')
 
+        # subscribe to topics
+        # waypoints for trajectory
         self.subs['/base_waypoints'] = \
             rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
+        # current pose of car
         self.subs['/current_pose'] = \
             rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
 
+        # current speed of car
         self.subs['/current_velocity'] = \
             rospy.Subscriber('/current_velocity', TwistStamped,
                              self.velocity_cb)
 
+        # If a red traffic light has been detected ahead
+        # the waypoint closest to the stopline will be sent out
+        # if no red light -1 will be sent
         self.subs['/traffic_waypoint'] = \
             rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
 
@@ -91,19 +159,523 @@ class WaypointUpdater(object):
                 self.send_waypoints()
             self.rate.sleep()
 
-    # adjust dynamic variables
+    def velocity_cb(self, twist_msg):
+        self.velocity = twist_msg
+
+    def pose_cb(self, pose_msg):
+        self.pose = pose_msg.pose
+        rospy.logdebug("waypoint_updater:pose_cb pose set to  %s", self.pose)
+
+    # Receive a msg from /traffic_waypoint about the next stop line
+    def traffic_cb(self, traffic_msg):
+        if traffic_msg.data != self.next_traffic_light_wp:
+            self.next_traffic_light_wp = traffic_msg.data
+            rospy.loginfo("new /traffic_waypoint message received at wp: %d."
+                          "while car is at wp %d", self.next_traffic_light_wp,
+                          self.final_waypoints_start_ptr)
+        else:
+            # just for debug to see what we're getting
+            rospy.logdebug("same /traffic_waypoint message received.")
+        # end if else
+
+    def send_waypoints(self):
+        # generates the list of LOOKAHEAD_WPS waypoints based on car location
+        # for now assume waypoints form a loop
+        # waypoints loaded into a deque with deepcopy
+        # buffer of rear_buffer points to use for location search
+        # final_waypoints_start_ptr refers to waypoint_ptr which will be start
+        # of published final_waypoints list
+        # last_waypoint was the initial waypoint in previous iteration
+
+        start_wps_ptr = self.closest_waypoint()
+        dequelen = len(self.f_wpdeq)
+        if self.final_waypoints_start_ptr < 0:
+            # condition on startup
+            self.final_waypoints_start_ptr = start_wps_ptr
+            self.last_waypoint = self.final_waypoints_start_ptr
+            end_waypoint_in_deque = self.last_waypoint - 1
+            # load buffer of points behind into deque
+            for w_ptr in range(end_waypoint_in_deque - self.rear_buffer,
+                               end_waypoint_in_deque+1):
+                wpd = deq_waypoint(w_ptr, copy.deepcopy(self.waypoints[w_ptr]))
+                self.f_wpdeq.append(wpd)
+        else:
+            self.last_waypoint = self.final_waypoints_start_ptr
+            end_waypoint_in_deque = self.f_wpdeq[dequelen - 1].\
+                ptr_id
+            self.final_waypoints_start_ptr = start_wps_ptr
+        # end if else
+
+        points_added = 0
+        last_waypoint_needed = (self.final_waypoints_start_ptr +
+                                self.lookahead_wps - 1) % len(self.waypoints)
+        if last_waypoint_needed == end_waypoint_in_deque:
+            rospy.loginfo("no movement, not adding to deque")
+        elif last_waypoint_needed > end_waypoint_in_deque:
+            for w_ptr in range(end_waypoint_in_deque+1,
+                               last_waypoint_needed+1):
+                wpd = deq_waypoint(w_ptr, copy.deepcopy(self.waypoints[w_ptr]))
+                self.f_wpdeq.append(wpd)
+                points_added += 1
+            # end of for
+        else:
+            for w_ptr in range(end_waypoint_in_deque+1, len(self.waypoints)):
+                # w_p.twist.twist.linear.x = self.default_velocity
+                wpd = deq_waypoint(w_ptr, copy.deepcopy(self.waypoints[w_ptr]))
+                self.f_wpdeq.append(wpd)
+                points_added += 1
+            # end of for
+            for w_ptr in range(last_waypoint_needed+1):
+                # w_p.twist.twist.linear.x = self.default_velocity
+                wpd = deq_waypoint(w_ptr, copy.deepcopy(self.waypoints[w_ptr]))
+                self.f_wpdeq.append(wpd)
+                points_added += 1
+            # end of for
+        # end of if
+        # #for ptr in range(end_waypoint_in_deque+1, last_waypoint_needed):
+        # self.f_wpdeq.append(copy.deepcopy(self.waypoints
+        # [end_waypoint_in_deque+1:last_waypoint_needed]))
+        rospy.loginfo("waypoint_updater:send_waypoints start_wps_ptr = %d,"
+                      " end_wps_ptr = %d, added %d points last item ptr = %d", start_wps_ptr,
+                      last_waypoint_needed, points_added, self.f_wpdeq[len(self.f_wpdeq)-1].ptr_id)
+
+        self.set_waypoints_velocity()
+        # rospy.loginfo("waypoint_updater:send_waypoints final_waypoints list"
+        #              " length is %d", len(new_wps_list))
+        lane = Lane()
+        
+        new_wps_list = []
+        for wpt in list(itertools.islice(self.f_wpdeq,
+                        self.rear_buffer, self.max_dequelen)):
+            new_wps_list.append(wpt.waypoint)
+            # rospy.loginfo("new_wps_list[{}].twist.twist.linear.x = {}".\
+            #               format(wpt.ptr_id, wpt.waypoint.twist.twist.linear.x))
+        # end for
+        # rospy.loginfo("new_wps_list len = {}".format(len(new_wps_list)))
+        lane.waypoints = list(new_wps_list)
+        lane.header.frame_id = '/world'
+        lane.header.stamp = rospy.Time.now()
+        self.pubs['/final_waypoints'].publish(lane)
+
+    def set_waypoints_velocity(self):
+        # adjust the velocities in the /final_waypoint queue
+        # TODO: move the waypoints to a structure there first so don't have to
+        # worry about looping
+        disp = 0  # set for logging
+
+        start_ptr = self.rear_buffer
+        last_wpd = self.f_wpdeq[start_ptr-1]
+        # for wpd in list(itertools.islice(self.f_wpdeq,
+        #  start_ptr,
+        #                                 self.max_dequelen)):
+
+        for l_ptr in range(start_ptr, self.max_dequelen):
+            if self.f_wpdeq[l_ptr].state in self.states:
+                self.state = self.f_wpdeq[l_ptr].state
+            # wpd = self.f_wpdeq[l_ptr]
+            calc = self.state_spinner(l_ptr-1, l_ptr)
+
+            if calc is True:
+
+                disp = self.distance(self.JMT_start_ptr, self.f_wpdeq[l_ptr].ptr_id)
+
+                if self.state == 'stopped':
+                    self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = 0.0
+                    self.f_wpdeq[l_ptr].V = 0.0
+                    self.f_wpdeq[l_ptr].A = 0.0
+                    self.f_wpdeq[l_ptr].J = 0.0
+                # end if
+
+                if self.state == 'maintainspeed':
+                    v = min(self.f_wpdeq[l_ptr].max_V, last_wpd.V)
+                    self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = v
+                    self.f_wpdeq[l_ptr].V = v
+                    self.f_wpdeq[l_ptr].A = 0.0
+                    self.f_wpdeq[l_ptr].J = 0.0
+                # end if
+
+                if self.state == 'JMTslowdown':              
+                    wp_check = self.JMTD_at(disp, self.JMTcoeffs, self.JMT_time,
+                                            self.JMT_max_time, l_ptr)
+                    if wp_check == -1:
+                        rospy.logwarn("JMTslowdown error - switch to maintainspeed")
+                        self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = last_wpd.V
+                        self.f_wpdeq[l_ptr].V = last_wpd.V
+                        self.state = 'maintainspeed'
+                    else:
+                        if self.f_wpdeq[l_ptr].V < 0.25:
+                            self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = 0.0
+                        else:
+                            self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = \
+                                min(self.f_wpdeq[l_ptr].V, self.f_wpdeq[l_ptr].max_V)
+                        # end for
+                    # end if else
+                # end if
+
+                if self.state == 'JMTspeedup':
+                    wp_check = self.JMTD_at(disp, self.JMTcoeffs, self.JMT_time,
+                                            self.JMT_max_time, l_ptr)
+                    if wp_check == -1:
+                        self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = \
+                            min(last_wpd.V, self.f_wpdeq[l_ptr].max_V)
+                        self.state = 'maintainspeed'  # Assume gone past end
+                        self.f_wpdeq[l_ptr].state = self.state
+                        self.JMTcoeffs = None
+                        self.JMT_start_ptr = self.f_wpdeq[l_ptr].ptr_id
+                        self.JMT_time = 0.0
+                        self.JMT_max_time = 0.0
+
+                    else:
+                        self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = \
+                            min(self.f_wpdeq[l_ptr].V, self.f_wpdeq[l_ptr].max_V)
+
+                if self.state == 'startspeedup':
+                    # dist = self.distance(last_wpd.ptr_id, self.f_wpdeq[l_ptr].ptr_id)
+                    self.f_wpdeq[l_ptr].A = self.default_accel
+                    v = max(0.5 , math.sqrt(self.f_wpdeq[l_ptr].A * disp * 2.0))
+                    v = min(v, self.f_wpdeq[l_ptr].max_V)
+                    self.f_wpdeq[l_ptr].V = v
+                    self.f_wpdeq[l_ptr].waypoint.twist.twist.linear.x = v
+
+                last_wpd = self.f_wpdeq[l_ptr]
+                rospy.loginfo("state = {}, ptr= {}, v= {}, a= {}, dist= {}".
+                            format(self.state, last_wpd.ptr_id, last_wpd.V,
+                                    last_wpd.A, disp))
+            else:
+                disp = self.distance(self.f_wpdeq[l_ptr].phase_start_ptr, self.f_wpdeq[l_ptr].ptr_id)
+                last_wpd = self.f_wpdeq[l_ptr]
+                rospy.loginfo("skipping recalculation "\
+                              "state = {}, ptr= {}, v= {}, a= {}, dist= {}".
+                              format(self.state, last_wpd.ptr_id, last_wpd.V,
+                                     last_wpd.A, disp))
+                
+
+    # check for state transitions
+    def state_spinner(self, last_dwp_ptr, dwp_ptr):
+
+        calc = True  # set to know if v has to be recalculated
+
+        last_deq_waypoint = self.f_wpdeq[last_dwp_ptr]
+        deq_waypoint = self.f_wpdeq[dwp_ptr]
+        if deq_waypoint.state is None:
+            if self.state not in ['JMTslowdown', 'stopped']:
+
+                if self.next_traffic_light_wp == -1:
+                    dist = 1000  # far away
+                else:
+                    dist = self.distance(deq_waypoint.ptr_id,
+                                         self.next_traffic_light_wp)
+
+                if dist < self.get_stopping_distance(last_deq_waypoint.V):
+                    self.state = 'JMTslowdown'
+                    # setup JMT for calcs
+
+                    end_wp = self.next_traffic_light_wp - 1
+                    dist = self.distance(deq_waypoint.ptr_id, end_wp)
+                    # try to bias to slowing down from start by setting A slightly negative
+                    start = list([0, last_deq_waypoint.V, last_deq_waypoint.A-0.1])
+                    end = list([dist, 0.0, 0.0])
+                    time = 2.0 * 2 * dist / last_deq_waypoint.V
+                    self.JMTcoeffs = self.JMT(start, end, time)
+                    self.JMT_start_ptr = deq_waypoint.ptr_id
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = time * 1.1
+                    rospy.logwarn("Start slowing down! Wpt = {},"
+                                  " start = {}, {}, {} "
+                                  "end = {}, {}, {} at T= {}".format(
+                                  deq_waypoint.ptr_id,
+                                  start[0], start[1], start[2],
+                                  end[0], end[1], end[2], time))
+
+                # end if
+            # end if
+
+            if self.state == 'startspeedup':
+                if last_deq_waypoint.V >= 1.5:
+                    self.state = 'JMTspeedup'
+                    d1 = self.distance(last_deq_waypoint.ptr_id,
+                                    deq_waypoint.ptr_id)
+                    self.f_wpdeq[dwp_ptr].V = math.sqrt(last_deq_waypoint.V**2 + 2 *
+                                            self.default_accel * d1)
+                    self.f_wpdeq[dwp_ptr].A = self.default_accel
+                    time = 2.0 * (self.default_velocity - self.f_wpdeq[dwp_ptr].V) / self.default_accel
+                    dist = (self.default_velocity - self.f_wpdeq[dwp_ptr].V) * time
+                    start = list([0, self.f_wpdeq[dwp_ptr].V, self.f_wpdeq[dwp_ptr].A])
+                    end = list([dist, self.default_velocity * 0.975, 0.0])
+                    self.JMTcoeffs = self.JMT(start, end, time)
+                    self.JMT_start_ptr = deq_waypoint.ptr_id
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = time * 1.1
+                    rospy.logwarn("Start JMT phase of accel! Wpt = {},"
+                                  " start = {}, {}, {} "
+                                  "end = {}, {}, {} at T= {}".format(
+                                  deq_waypoint.ptr_id,
+                                  start[0], start[1], start[2],
+                                  end[0], end[1], end[2], time))
+
+                # end if
+            # end if
+
+            elif self.state == 'JMTspeedup':
+                if last_deq_waypoint.V >= self.default_velocity * 0.975:
+                    # and (last_deq_waypoint.A < 0.3)):
+                    self.state = 'maintainspeed'
+                    rospy.logwarn("Switch to maintainspeed. Wpt = {}".format(
+                                deq_waypoint.ptr_id))
+                    self.JMTcoeffs = None
+                    self.JMT_start_ptr = self.f_wpdeq[dwp_ptr].ptr_id - 1
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id - 1
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = 0.0
+                # end if
+            # end if
+
+            elif self.state == 'JMTslowdown':
+                if last_deq_waypoint.V <= 0.2:
+                    self.f_wpdeq[dwp_ptr].V = 0.0
+                    self.f_wpdeq[dwp_ptr].A = 0.0
+                    self.state = 'stopped'
+                    rospy.logwarn("Switch to stopped! Wpt = {}".format(
+                                deq_waypoint.ptr_id))
+                    self.JMTcoeffs = None
+                    self.JMT_start_ptr = self.f_wpdeq[dwp_ptr].ptr_id
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = 0.0
+                # end if
+            # end if
+
+            elif self.state == 'stopped':
+                if (self.distance(deq_waypoint.ptr_id,
+                                self.next_traffic_light_wp) > 10.0):
+                    self.state = 'startspeedup'
+                    self.JMT_start_ptr = self.f_wpdeq[dwp_ptr].ptr_id
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id
+                    rospy.logwarn("Time to start moving! Wpt = {}".format(
+                                deq_waypoint.ptr_id))
+                # end if
+            # end if
+            self.f_wpdeq[dwp_ptr].phase_start_ptr = self.JMT_start_ptr
+
+        else:  # state set on waypoint - we've already calculated it
+
+            self.state = self.f_wpdeq[dwp_ptr].state
+            if self.next_traffic_light_wp == -1:
+                dist = 1000
+            else:
+                dist = self.distance(deq_waypoint.ptr_id,
+                                     self.next_traffic_light_wp)
+
+            if self.state not in ['stopped', 'JMTslowdown']:
+
+                if dist < self.get_stopping_distance(last_deq_waypoint.V):
+                    self.state = 'JMTslowdown'
+                    # setup JMT for calcs
+
+                    end_wp = self.next_traffic_light_wp - 1
+                    dist2 = self.distance(deq_waypoint.ptr_id, end_wp)
+                    start = list([0, last_deq_waypoint.V, last_deq_waypoint.A - 0.1])
+                    end = list([dist2, 0.0, 0.0])
+                    time = 2.0 * 2.0 * dist / last_deq_waypoint.V
+                    # time = 1.5 * (last_deq_waypoint.V / self.default_accel)
+                    self.JMTcoeffs = self.JMT(start, end, time)
+                    self.JMT_start_ptr = deq_waypoint.ptr_id - 1
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id - 1
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = time * 1.1
+                    rospy.logwarn("Reset to slowing down! Wpt = {},"
+                                  " start = {}, {}, {} "
+                                  "end = {}, {}, {} at T= {}".format(
+                                  deq_waypoint.ptr_id,
+                                  start[0], start[1], start[2],
+                                  end[0], end[1], end[2], time))
+                # end if
+            # end if
+
+            elif self.state == 'stopped':
+                if dist > 10.0:
+                    self.state = 'startspeedup'
+                    self.JMT_start_ptr = self.f_wpdeq[dwp_ptr].ptr_id
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id - 1
+                    rospy.logwarn("Time to start moving! Wpt = {}".format(
+                                deq_waypoint.ptr_id))
+                # end if
+            # end if
+
+            elif self.state == 'JMTslowdown':
+                if dist > 130.0:
+                    self.state = 'JMTspeedup'
+                    rospy.logwarn("Switch to JMTspeedup! Wpt = {}".format(
+                                deq_waypoint.ptr_id))
+                    d1 = self.distance(last_deq_waypoint.ptr_id,
+                                    deq_waypoint.ptr_id)
+                    self.f_wpdeq[dwp_ptr].V = math.sqrt(last_deq_waypoint.V**2 + 2 *
+                                            last_deq_waypoint.A * d1)
+                    self.f_wpdeq[dwp_ptr].A = last_deq_waypoint.A
+                    time = 2.0 * (self.default_velocity - self.f_wpdeq[dwp_ptr].V) / self.default_accel
+                    dist = (self.default_velocity - self.f_wpdeq[dwp_ptr].V) * time
+                    start = list([0, self.f_wpdeq[dwp_ptr].V, self.f_wpdeq[dwp_ptr].A])
+                    end = list([dist, self.default_velocity, 0.0])
+                    self.JMTcoeffs = self.JMT(start, end, time)
+                    self.f_wpdeq[dwp_ptr].phase_start_ptr = deq_waypoint.ptr_id
+                    self.JMT_start_ptr = deq_waypoint.ptr_id
+                    self.JMT_time = 0.0
+                    self.JMT_max_time = time * 1.1
+                    rospy.logwarn("Switch to start speeding up! Wpt = {},"
+                                  " start = {}, {}, {} "
+                                  "end = {}, {}, {} at T= {}".format\
+                                  (deq_waypoint.ptr_id,
+                                   start[0], start[1], start[2],
+                                   end[0], end[1], end[2], time))
+
+                # end if
+            # end if
+
+            # reset state on all remaining items in deque if we need to recalc traj
+            if self.f_wpdeq[dwp_ptr].state != self.state:
+                self.f_wpdeq[dwp_ptr].state = self.state
+                for l_ptr2 in range(dwp_ptr+1, self.max_dequelen-1):
+                        self.f_wpdeq[l_ptr2].state = None
+                        self.f_wpdeq[l_ptr2].phase_start_ptr = 0
+            else:
+                calc = False
+
+        self.f_wpdeq[dwp_ptr].state = self.state
+        return calc
+
+    def obstacle_cb(self, msg):
+        # TODO: Callback for /obstacle_waypoint message.
+        # We will implement it later
+        pass
+
+    # Load set of waypoints from /basewaypoints into self.waypoints
+    # this should only happen once, so we unsubscribe at end
+    def waypoints_cb(self, lane_msg):
+        rospy.loginfo("waypoint_updater:waypoints_cb loading waypoints")
+        if not self.waypoints:
+            max_velocity = 0.0
+            for waypoint in lane_msg.waypoints:
+                self.waypoints.append(waypoint)
+                if max_velocity < self.get_waypoint_velocity(waypoint):
+                    max_velocity = self.get_waypoint_velocity(waypoint)
+                # end if
+            rospy.loginfo("waypoint_updater:waypoints_cb %d waypoints loaded",
+                          len(self.waypoints))
+            # setting max velocity based on project requirements in
+            # Waypoint Updater Node Revisited
+            self.max_velocity = max_velocity
+            rospy.loginfo("waypoint_updater:waypoints_cb max_velocity set to "
+                          " {} based on max value in waypoints."
+                          .format(self.max_velocity))
+            # now max_velocity is known, set up dynamic reconfig
+            if not self.dyn_reconf_srv:
+                self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
+                rospy.loginfo("dynamic_parm server started")
+            # end if
+        else:
+            rospy.logerr("waypoint_updater:waypoints_cb attempt to load "
+                         "waypoints when we have already loaded %d waypoints",
+                         len(self.waypoints))
+        # end if else
+        self.subs['/base_waypoints'].unregister()
+        rospy.loginfo("Unregistered from /base_waypoints topic")
+
+    def get_waypoint_velocity(self, waypoint):
+        return waypoint.twist.twist.linear.x
+
+    def set_waypoint_velocity(self, waypointlist, waypoint, velocity):
+        waypointlist[waypoint].twist.twist.linear.x = velocity
+
+    def closest_waypoint(self):
+        # TODO:
+        # Require 2+ consecutive increases to end search in case of pose noise
+        # Make search more generic and switch order of search direction based
+        #  on last search direction
+        def distance_lambda(a, b): return math.sqrt(
+            (a.x-b.x)**2 + (a.y-b.y)**2)
+        if self.f_wpdeq:
+            dist = distance_lambda(self.f_wpdeq[self.
+                                   rear_buffer-1].waypoint.pose.pose.position,
+                                   self.pose.position)
+            # if self.back_search is True:
+            for i in range(self.rear_buffer, self.max_dequelen):
+                tmpdist = distance_lambda(self.f_wpdeq[i].
+                                          waypoint.pose.pose.position,
+                                          self.pose.position)
+
+                if tmpdist < dist:
+                    dist = tmpdist
+                else:
+                    # distance is starting to get larger so look at
+                    # last position
+                    if (i == self.rear_buffer+1):
+                        # we're closest to original waypoint, but what if
+                        # we're going backwards - loop backwards to make sure
+                        # a point further back  isn't closest
+                        for j in range(self.rear_buffer - 1, 0, -1):
+                            tmpdist = \
+                                distance_lambda(self.f_wpdeq[j].
+                                                waypoint.pose.pose.position,
+                                                self.pose.position)
+
+                            if tmpdist < dist:
+                                dist = tmpdist
+                                self.back_search = True
+                            else:
+                                if abs(dist-self.last_search_distance) < 5.0:
+                                    self.last_search_distance = dist
+                                    return self.f_wpdeq[j+1].\
+                                        ptr_id
+                                else:
+                                    break
+                            # end if else
+                        # end for - reverse loop
+                    # end if
+
+                    if abs(dist-self.last_search_distance) < 5.0:
+                        self.last_search_distance = dist
+                        return self.f_wpdeq[i-1].ptr_id
+                    # end if
+                # end if else
+            # end for - fall out no closest match that looks acceptable
+            rospy.logwarn("waypoint_updater:closest_waypoint local search not"
+                          "satisfied - run full search")
+        # end if
+
+        dist = 1000000  # maybe should use max
+        closest = 0
+        for i in range(len(self.waypoints)):
+            tmpdist = distance_lambda(self.waypoints[i].pose.pose.position,
+                                      self.pose.position)
+            if tmpdist < dist:
+                closest = i
+                dist = tmpdist
+            # end of if
+        # end of for
+        self.last_search_distance = dist
+        return closest
+        # Note: the first waypoint is closest to the car, not necessarily in
+        # front of it.  Waypoint follower is responsible for finding this
+
     def dyn_vars_cb(self, config, level):
+        # adjust dynamic variables
+
         self.dyn_vals_received = True
         if self.update_rate:
             old_update_rate = self.update_rate
             old_default_velocity = self.default_velocity
+            old_default_accel = self.default_accel
             old_lookahead_wps = self.lookahead_wps
             old_test_stoplight_wp = self.next_traffic_light_wp
         # end if
 
-        rospy.loginfo("Received dynamic parameters {} with level: {}"
-                      .format(config, level))
+        rospy.logdebug("Received dynamic parameters {} with level: {}"
+                       .format(config, level))
 
+        # TODO:could probably replace a lot of this code by setting up a list
+        # of dynamic params, iterating through it, and then running any actions
         if old_update_rate != config['dyn_update_rate']:
             rospy.loginfo("waypoint_updater:dyn_vars_cb Adjusting update Rate "
                           "from {} to {}".format(old_update_rate,
@@ -143,236 +715,25 @@ class WaypointUpdater(object):
                           .format(old_test_stoplight_wp,
                                   config['dyn_test_stoplight_wp']))
             self.next_traffic_light_wp = config['dyn_test_stoplight_wp']
+            self.slow_down = False  # reset
         # end if
+
+        if old_default_accel != config['dyn_default_accel']:
+            rospy.logwarn("waypoint_updater:dyn_vars_cb Adjusting default_"
+                          "accel from {} to {}"
+                          .format(old_default_accel,
+                                  config['dyn_default_accel']))
+            self.default_accel = config['dyn_default_accel']
 
         # we can also send adjusted values back
         return config
 
-    def velocity_cb(self, twist_msg):
-        self.velocity = twist_msg
-
-    def pose_cb(self, pose_msg):
-        self.pose = pose_msg.pose
-        rospy.logdebug("waypoint_updater:pose_cb pose set to  %s", self.pose)
-
-    # Load set of waypoints from /basewaypoints into self.waypoints
-    # this should only happen once, so we unsubscribe at end
-    def waypoints_cb(self, lane_msg):
-        rospy.loginfo("waypoint_updater:waypoints_cb loading waypoints")
-        if not self.waypoints:
-            max_velocity = 0.0
-            for waypoint in lane_msg.waypoints:
-                self.waypoints.append(waypoint)
-                if max_velocity < self.get_waypoint_velocity(waypoint):
-                    max_velocity = self.get_waypoint_velocity(waypoint)
-                # end if
-            rospy.loginfo("waypoint_updater:waypoints_cb %d waypoints loaded",
-                          len(self.waypoints))
-            # setting max velocity based on project requirements in
-            # Waypoint Updater Node Revisited
-            self.max_velocity = max_velocity
-            rospy.loginfo("waypoint_updater:waypoints_cb max_velocity set to "
-                          " {} based on max value in waypoints."
-                          .format(self.max_velocity))
-            # now max_velocity is known, set up dynamic reconfig
-            if not self.dyn_reconf_srv:
-                self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
-                rospy.loginfo("dynamic_parm server started")
-            # end if
-        else:
-            rospy.logerr("waypoint_updater:waypoints_cb attempt to load "
-                         "waypoints when we have already loaded %d waypoints",
-                         len(self.waypoints))
-        # end if else
-        self.subs['/base_waypoints'].unregister()
-        rospy.loginfo("Unregistered from /base_waypoints topic")
-
-    # Receive a msg from /traffic_waypoint about the next stop line
-    def traffic_cb(self, traffic_msg):
-        if traffic_msg.data != self.next_traffic_light_wp:
-            # do we need to queue these or will I only get the next one
-            # coming up?
-            # If car is stopped do I need to ramp up velocity, then
-            # down to reach it?
-            self.next_traffic_light_wp = traffic_msg.data
-            rospy.loginfo("new /traffic_waypoint message received at wp: %d."
-                          "while car is at wp %d", self.next_traffic_light_wp,
-                          self.final_waypoints_start_ptr)
-        else:
-            # just for debug to see what we're getting
-            rospy.loginfo("same /traffic_waypoint message received.")
-
-    # adjust the velocities in the /final_waypoint queue
-    # TODO: move the waypoints to a structure there first so don't have to
-    # worry about looping
-    def set_waypoints_velocity(self):
-        # this can happen before we get a traffic_wp msg
-        if not self.next_traffic_light_wp:
-            # set one up behind car - is this a problem if we reverse?
-            # STUB in putting it at 759 to see if it works
-            # next_traffic_light_wp = self.final_waypoints_start_ptr - 1
-            self.next_traffic_light_wp = 759
-            next_traffic_light_wp = self.next_traffic_light_wp
-        else:
-            next_traffic_light_wp = self.next_traffic_light_wp
-        # end if else
-        if ((next_traffic_light_wp - self.final_waypoints_start_ptr) %
-                len(self.waypoints)) < 100:
-            start_ptr = self.final_waypoints_start_ptr + 5
-            end_ptr = next_traffic_light_wp
-            distance_to_rl = self.distance(start_ptr, end_ptr)
-            velocity = self.waypoints[start_ptr].twist.twist.linear.x
-            # time_to_decel = 2 * distance_to_rl / velocity
-            # accel = - velocity / time_to_decel
-            chord_dist = 0
-            final_end_ptr = self.final_waypoints_start_ptr + self.lookahead_wps
-            if distance_to_rl < 1.0:  # small buffer from stop line
-                for ptr in range(start_ptr, final_end_ptr):
-                    mod_ptr = ptr % len(self.waypoints)
-                    self.waypoints[mod_ptr].twist.twist.linear.x = 0.0
-                # end for
-            else:
-                for ptr in range(start_ptr, final_end_ptr):
-                    # self.next_traffic_light_wp):
-                    mod_ptr = ptr % len(self.waypoints)
-                    chord_dist += self.distance(ptr, ptr+1)
-                    v = (1-chord_dist/distance_to_rl)*velocity
-                    if v < 0.9:
-                        v = 0.0
-                    self.waypoints[mod_ptr].twist.twist.linear.x = v
-                # end for
-            # end if else
-        else:
-            # if self.velocity < self.default_velocity:
-            #    waypoints[self.final_waypoints_start_ptr + 5].twist.twist.\
-            #        linear.x == self.velocity:
-            start_ptr = self.final_waypoints_start_ptr
-            final_end_ptr = self.final_waypoints_start_ptr + self.lookahead_wps
-            for ptr in range(start_ptr, final_end_ptr):
-                mod_ptr = ptr % len(self.waypoints)
-                self.waypoints[mod_ptr].twist.twist.linear.x = \
-                    self.default_velocity
-                # end for
-            # end if
-        # maybe this should be called from main loop
-
-    def obstacle_cb(self, msg):
-        # TODO: Callback for /obstacle_waypoint message.
-        # We will implement it later
-        pass
-
-    def send_waypoints(self):
-        # generates the list of LOOKAHEAD_WPS waypoints based on car location
-        # for now assume waypoints form a loop
-        new_wps_list = []
-        start_wps_ptr = self.closest_waypoint()
-        end_wps_ptr = (start_wps_ptr +
-                       self.lookahead_wps) % len(self.waypoints)
-        rospy.loginfo("waypoint_updater:send_waypoints start_wps_ptr = %d,"
-                      " end_wps_ptr = %d", start_wps_ptr, end_wps_ptr)
-        if end_wps_ptr > start_wps_ptr:
-            for w_p in self.waypoints[start_wps_ptr:end_wps_ptr]:
-                # w_p.twist.twist.linear.x = self.default_velocity
-                new_wps_list.append(w_p)
-            # end of for
-        else:
-            for w_p in self.waypoints[start_wps_ptr:]:
-                # w_p.twist.twist.linear.x = self.default_velocity
-                new_wps_list.append(w_p)
-            # end of for
-            for w_p in self.waypoints[:end_wps_ptr]:
-                # w_p.twist.twist.linear.x = self.default_velocity
-                new_wps_list.append(w_p)
-            # end of for
-        # end of if
-        # for now this should work, as no deepcopy. lets see
-        self.set_waypoints_velocity()
-        rospy.loginfo("waypoint_updater:send_waypoints final_waypoints list"
-                      " length is %d", len(new_wps_list))
-        lane = Lane()
-        lane.waypoints = list(new_wps_list)
-        lane.header.frame_id = '/world'
-        lane.header.stamp = rospy.Time()
-        self.pubs['/final_waypoints'].publish(lane)
-        self.final_waypoints = list(new_wps_list)
-        self.final_waypoints_start_ptr = start_wps_ptr
-
-    def get_waypoint_velocity(self, waypoint):
-        return waypoint.twist.twist.linear.x
-
-    def set_waypoint_velocity(self, waypointlist, waypoint, velocity):
-        waypointlist[waypoint].twist.twist.linear.x = velocity
-
-    def closest_waypoint(self):
-        # TODO - use local search first of final_waypoints sent out last
-        # iteration
-        def distance_lambda(a, b): return math.sqrt(
-            (a.x-b.x)**2 + (a.y-b.y)**2)
-        if self.final_waypoints:
-            dist = distance_lambda(self.final_waypoints[0].pose.pose.position,
-                                   self.pose.position)
-            for i in range(1, len(self.final_waypoints)):
-                tmpdist = distance_lambda(self.final_waypoints[i].pose.pose.
-                                          position, self.pose.position)
-                if tmpdist < dist:
-                    dist = tmpdist
-                else:
-                    # distance is starting to get larger so look at
-                    # last position
-                    if (i == 1):
-                        # we're closest to original waypoint, but what if
-                        # we're going backwards - loop backwards to make sure
-                        # a point further back  isn't closest
-                        for j in range(self.final_waypoints_start_ptr-1,
-                                       self.final_waypoints_start_ptr -
-                                       len(self.final_waypoints),
-                                       -1):
-                            tmpdist = distance_lambda(
-                                self.waypoints[j % len(self.waypoints)].
-                                pose.pose.position,
-                                self.pose.position)
-                            if tmpdist < dist:
-                                dist = tmpdist
-                                self.back_search = True
-                            else:
-                                if abs(dist-self.last_search_distance) < 5.0:
-                                    self.last_search_distance = dist
-                                    return ((j+1) % len(self.waypoints))
-                                else:
-                                    break
-                            # end if else
-                        # end for
-                    # end if
-
-                    if abs(dist-self.last_search_distance) < 5.0:
-                        self.last_search_distance = dist
-                        return ((self.final_waypoints_start_ptr + i - 1) %
-                                len(self.waypoints))
-                    # end if
-                # end if else
-            # end for - fall out no closest match that looks acceptable
-            rospy.logwarn("waypoint_updater:closest_waypoint local search not"
-                          "satisfied - run full search")
-        # end if
-
-        dist = 1000000  # maybe should use max
-        closest = 0
-        for i in range(len(self.waypoints)):
-            tmpdist = distance_lambda(self.waypoints[i].pose.pose.position,
-                                      self.pose.position)
-            if tmpdist < dist:
-                closest = i
-                dist = tmpdist
-            # end of if
-        # end of for
-        self.last_search_distance = dist
-        return closest
-        # Note: the first waypoint is closest to the car, not necessarily in
-        # front of it.  Waypoint follower is responsible for finding this
-
-    # Todo need to adjust for looping
     def distance(self, wp1, wp2):
+        # TODO need to adjust for looping or reverse
+
         dist = 0
+        if wp1 == wp2:
+            return 0.0
 
         def distance_lambda(a, b): return math.sqrt((a.x-b.x)**2 +
                                                     (a.y-b.y)**2 +
@@ -382,6 +743,93 @@ class WaypointUpdater(object):
                                     self.waypoints[i].pose.pose.position)
             wp1 = i
         return dist
+
+    def get_stopping_distance(self, velocity):
+        # reasonable guess of distance needed to stop at speed and
+        # max decceleration rate
+
+        safety_factor = 1.2  # this should be much smaller with braking
+        distance_needed = velocity * velocity / (2.0 * self.default_accel)
+        distance_needed *= safety_factor
+        # if distance_needed > 0.0 and distance_needed < 75.0:
+        #    rospy.loginfo("Stopping Distance Needed is {}".
+        #                  format(distance_needed))
+        return distance_needed
+
+    def JMT(self, start, end, T):
+        """
+        Calculates Jerk Minimizing Trajectory for start, end and T.
+        """
+        a_0, a_1, a_2 = start[0], start[1], start[2] / 2.0
+        c_0 = a_0 + a_1 * T + a_2 * T**2
+        c_1 = a_1 + 2 * a_2 * T
+        c_2 = 2 * a_2
+
+        A = np.array([
+                     [T**3,   T**4,    T**5],
+                     [3*T**2, 4*T**3,  5*T**4],
+                     [6*T,   12*T**2, 20*T**3],
+                     ])
+
+        B = np.array([
+                     end[0] - c_0,
+                     end[1] - c_1,
+                     end[2] - c_2
+                     ])
+        a_3_4_5 = np.linalg.solve(A, B)
+        alphas = np.concatenate([np.array([a_0, a_1, a_2]), a_3_4_5])
+        return alphas
+
+    def JMTD_at(self, displacement, coeffs, t0, tmax, deq_wpt_ptr):
+        # find JMT descriptors at displacement
+        s_last = 0.0
+        t_found = False
+        t_inc = 0.005
+
+        for t_cnt in range(int((tmax-t0)/t_inc) + 1):
+
+            t = t0 + t_cnt * t_inc
+            s = coeffs[0] + coeffs[1]*t + coeffs[2]*t*t + coeffs[3]*t*t*t +\
+                coeffs[4]*t*t*t*t + coeffs[5]*t*t*t*t*t
+            if s > displacement:
+                t = t - (1 - (s - displacement) / (s - s_last)) * t_inc
+                t_found = True
+                break
+            # end if
+            s_last = s
+        # end for
+        if t_found is False:
+            rospy.logerr("waypoint_updater:JMTDat Ran out of bounds without "
+                         "finding target displacement")
+            return(-1)
+        self.JMT_time = t
+        t2 = t*t
+        t3 = t2*t
+        t4 = t3*t
+        t5 = t4*t
+
+        s = coeffs[0] + coeffs[1]*t + coeffs[2]*t2 + coeffs[3]*t3 +\
+            coeffs[4]*t4 + coeffs[5]*t5
+        v = coeffs[1] + 2*coeffs[2]*t +\
+            3*coeffs[3]*t2 + 4*coeffs[4]*t3 + 5*coeffs[5]*t4
+        a = 2*coeffs[2] + 6*coeffs[3]*t + 12*coeffs[4]*t2 +\
+            20*coeffs[5]*t3
+        j = 6*coeffs[3] + 24*coeffs[4]*t + 60*coeffs[5]*t2
+
+        delta_s = (displacement - s)
+        if delta_s > 0.1:
+            rospy.logwarn("waypoint_updater:JMTD_at need to refine algo,"
+                          " delta_s is {}".format(delta_s))
+
+        self.f_wpdeq[deq_wpt_ptr].waypoint.twist.twist.linear.x = v
+        self.f_wpdeq[deq_wpt_ptr].V = v
+        self.f_wpdeq[deq_wpt_ptr].A = a
+        self.f_wpdeq[deq_wpt_ptr].J = j 
+
+        rospy.loginfo("waypoint_updater:JMTD_at for displacement {} found s= {}, at t= {}, v={}, a={}"
+                      .format(displacement, s, t, v, a))
+
+        return v
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uses a deque and JMT to calculate velocity at waypoints. re: issue #23

will create startup and slowdown profile, so that we can talk about how to adjust them.

currently crashes when generating slowdown profile.   searching beyond limit when trying to find final state during JMTslowdown - possibly could be fixed by extending search further in JMTD_at

Also, program overwrites JMT setup (coeffs) for one state(e.g JMTspeedup) when it moves into another JMT state (e,g) JMTslowdown.  On the next iteration we might need the setup details again. Worked around this by reducing the deque size so unlikely for this to happen, but it probably will.

Questions: Do you know if there is a better way to determine the velocities with the JMT approach as opposed to the brute force way I've done it where I calculate displacement at fine time intervals, and try to match the required displacement?  

Do you have particular suggestions about the curves or the code?
