### PR TITLE
Visualization:  Change visualization base wp path from continuous to single latched publish 

### DIFF
--- a/ros/src/visualization/vis_node.py
+++ b/ros/src/visualization/vis_node.py
@@ -38,7 +38,8 @@ class VisNode(object):
                     '/visualization_marker_array', MarkerArray, queue_size=1)
 
         self.pubs['/visualization_basewp_path'] = rospy.Publisher(
-                    '/visualization_basewp_path', Path, queue_size=1)
+                    '/visualization_basewp_path', Path, queue_size=1,
+                    latch=True)
 
         self.subs['/current_pose'] = rospy.Subscriber(
                     '/current_pose', PoseStamped, self.handle_current_pose_msg)
@@ -71,9 +72,18 @@ class VisNode(object):
         self.basewp_poses = []  # clear again just in case
         for wp_idx in range(len(base_wp_msg.waypoints)):
             self.base_waypoints.append(base_wp_msg.waypoints[wp_idx])
-            if wp_idx % 100 == 0:  # thin out points for path msg
+            if wp_idx % 10 == 0:  # thin out points for path msg
                 self.basewp_poses.append(base_wp_msg.waypoints[wp_idx].pose)
         self.subs['/base_waypoints'].unregister()
+
+        # Publish base waypoint path for RViz
+        basewp_header = Header()
+        basewp_header.frame_id = "/world"
+        basewp_header.stamp = rospy.Time()
+        basewp_path = Path()
+        basewp_path.header = basewp_header
+        basewp_path.poses = self.basewp_poses
+        self.pubs['/visualization_basewp_path'].publish(basewp_path)
 
     # Callback to handle final waypoints message
     def handle_final_waypoints_msg(self, final_wp_msg):
@@ -153,31 +163,9 @@ class VisNode(object):
                     car_marker.pose = self.current_pose
                     marker_array.markers.append(car_marker)
 
-                # Base Waypoint Line (switched to using built-in path instead)
-                '''
-                base_wp_line = Marker()
-                base_wp_line.id = 1
-                base_wp_line.header.frame_id = "/world"
-                base_wp_line.header.stamp = rospy.Time()
-                base_wp_line.type = Marker.LINE_STRIP
-                base_wp_line.action = Marker.ADD
-                base_wp_line.scale.x = 2.0
-                base_wp_line.scale.y = 2.0
-                base_wp_line.scale.z = 2.0
-                base_wp_line.color.a = 1.0
-                base_wp_line.color.r = 1.0
-                base_wp_line.color.g = 1.0
-                base_wp_line.color.b = 1.0
-                for wp_idx in range(len(self.base_waypoints)):
-                    if wp_idx % 30 == 0:
-                        base_wp_line.points.append(
-                                self.base_waypoints[wp_idx].pose.pose.position)
-                marker_array.markers.append(base_wp_line)
-                '''
-
                 # Final Waypoint Line
                 final_wp_line = Marker()
-                final_wp_line.id = 2
+                final_wp_line.id = 1
                 final_wp_line.header.frame_id = "/world"
                 final_wp_line.header.stamp = rospy.Time()
                 final_wp_line.type = Marker.LINE_STRIP
@@ -199,7 +187,7 @@ class VisNode(object):
 
                 # Traffic Waypoint Spheres
                 tl_marker = Marker()
-                tl_marker.id = 3
+                tl_marker.id = 2
                 tl_marker.header.frame_id = "/world"
                 tl_marker.header.stamp = rospy.Time()
                 tl_marker.type = Marker.SPHERE_LIST
@@ -222,7 +210,7 @@ class VisNode(object):
                         and self.traffic_waypoint >= 0
                         and self.traffic_waypoint < len(self.base_waypoints)):
                     det_tl_marker = Marker()
-                    det_tl_marker.id = 4
+                    det_tl_marker.id = 3
                     det_tl_marker.header.frame_id = "/world"
                     det_tl_marker.header.stamp = rospy.Time()
                     det_tl_marker.type = Marker.CUBE
@@ -243,15 +231,6 @@ class VisNode(object):
 
                 # Publish final array of markers for RViz
                 self.pubs['/visualization_marker_array'].publish(marker_array)
-
-                # Publish base waypoint path for RViz
-                basewp_header = Header()
-                basewp_header.frame_id = "/world"
-                basewp_header.stamp = rospy.Time()
-                basewp_path = Path()
-                basewp_path.header = basewp_header
-                basewp_path.poses = self.basewp_poses
-                self.pubs['/visualization_basewp_path'].publish(basewp_path)
 
             self.rate.sleep()
 


### PR DESCRIPTION
Set base waypoint path to publish once and latch instead of continuously publishing to save bandwidth.  Increase waypoint resolution and clean up code.