### PR TITLE
Pull update from Udacity base repo for dbw_test.py

### DIFF
--- a/ros/src/twist_controller/dbw_test.py
+++ b/ros/src/twist_controller/dbw_test.py
@@ -10,9 +10,11 @@ from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 
 '''
 You can use this file to test your DBW code against a bag recorded with a reference implementation.
-The bag can be found at https://drive.google.com/open?id=0B2_h37bMVw3iT0ZEdlF4N01QbHc.
+The bag can be found at https://s3-us-west-1.amazonaws.com/udacity-selfdrivingcar/files/reference.bag.zip
 
-To use the downloaded bag file, rename it to 'dbw_test.rosbag.bag' and place it in the CarND-Capstone/data folder
+To use the downloaded bag file, rename it to 'dbw_test.rosbag.bag' and place it in the CarND-Capstone/data folder.
+Then with roscore running, you can then use roslaunch with the dbw_test.launch file found in 
+<project_repo>/ros/src/twist_controller/launch.
 
 This file will produce 3 csv files which you can process to figure out how your DBW node is
 performing on various commands.

--- a/ros/src/twist_controller/dbw_test.py
+++ b/ros/src/twist_controller/dbw_test.py
@@ -12,6 +12,8 @@ from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 You can use this file to test your DBW code against a bag recorded with a reference implementation.
 The bag can be found at https://drive.google.com/open?id=0B2_h37bMVw3iT0ZEdlF4N01QbHc.
 
+To use the downloaded bag file, rename it to 'dbw_test.rosbag.bag' and place it in the CarND-Capstone/data folder
+
 This file will produce 3 csv files which you can process to figure out how your DBW node is
 performing on various commands.
 


### PR DESCRIPTION
Udacity just updated their dbw_test.py to include a link to a reference bag data and how to use the test file to compare to our DBW's output.  Let's merge it and check it out.