### PR TITLE
Add low pass filter to DBW throttle and brake commands to prevent large, rapid actuations

### DIFF
--- a/ros/src/twist_controller/cfg/DynReconf.cfg
+++ b/ros/src/twist_controller/cfg/DynReconf.cfg
@@ -11,7 +11,7 @@ gen = ParameterGenerator()
 gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.1, 0, 4)
 gen.add("dyn_velo_integral_control", double_t, 0, "Velocity integral control constant", 0.01, 0, 4.0)
 
-gen.add("dyn_braking_proportional_control", double_t, 0, "Braking proportional control constant", 100, 0, 1000)
+gen.add("dyn_braking_proportional_control", double_t, 0, "Braking proportional control constant", 300, 0, 1000)
 gen.add("dyn_braking_integral_control", double_t, 0, "Braking integral control constant", 0, 0, 4.0)
 
 exit(gen.generate(PACKAGE, "twist_controller", "DynReconf"))


### PR DESCRIPTION
For #50 - this work adds a low pass filter to the throttle and brake actuation commands in an attempt to remove rapid actuations.