### PR TITLE
Reduce processing load

### DIFF
--- a/ros/src/visualization/cfg/DynReconf.cfg
+++ b/ros/src/visualization/cfg/DynReconf.cfg
@@ -8,7 +8,7 @@ PACKAGE = "visualization"
 
 gen = ParameterGenerator()
 
-gen.add("dyn_vis_enabled", bool_t, 0, "enable flag", True)
+gen.add("dyn_vis_enabled", bool_t, 0, "enable flag", False)
 gen.add("dyn_vis_rate", int_t, 0, "update rate in Hz", 5, 1, 50)
 
 exit(gen.generate(PACKAGE, "visualization", "DynReconf"))

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -535,11 +535,11 @@ class WaypointUpdater(object):
             rospy.logwarn("recalc is set to {} we should recalculate"
                           .format(recalc))
 
-        rospy.loginfo("ptr_id, JMT_ptr, time, S, V, A, J")
+        rospy.logdebug("ptr_id, JMT_ptr, time, S, V, A, J")
         for wpt in self.waypoints[self.final_waypoints_start_ptr:
                                   self.final_waypoints_start_ptr +
                                   self.lookahead_wps]:
-            rospy.loginfo("{}, {}, {}".format(wpt.ptr_id, wpt.JMT_ptr, wpt.JMTD))
+            rospy.logdebug("{}, {}, {}".format(wpt.ptr_id, wpt.JMT_ptr, wpt.JMTD))
 
     def setup_jmt(self, curpt, target_velocity, accel_ratio=1.0,
                   time_factor=1.0):


### PR DESCRIPTION
Change default to disable visualization node and change JMT profile output to logdebug to help reduce processing load.