### PR TITLE
Waypoint Follower: Fix lookahead waypoint for test lot tight turns

### DIFF
--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -99,14 +99,14 @@ public:
     , const_lookahead_distance_(4.0)
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
-    , minimum_lookahead_distance_(6.0)
+    , minimum_lookahead_distance_(4.0) // shorten for tight turn in test lot
     , displacement_threshold_(0.05)
     , relative_angle_threshold_(0.5)
     , waypoint_set_(false)
     , pose_set_(false)
     , velocity_set_(false)
     , num_of_next_waypoint_(-1)
-    , closest_waypoint_idx_(-1)
+    , closest_waypoint_idx_(0) // default to first waypoint for index lookup
     , lookahead_distance_(0)
   {
   }

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -328,8 +328,9 @@ void PurePursuit::getNextWaypoint()
     return;
   }
 
-  // look for the next waypoint.
-  for (int i = 0; i < path_size; i++)
+  // look for the next waypoint, starting from closest waypoint to prevent
+  // searching behind the car
+  for (int i = closest_waypoint_idx_; i < path_size; i++)
   {
     // if search waypoint is the last
     if (i == (path_size - 1))

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -293,7 +293,7 @@ void PurePursuit::getClosestWaypoint() {
   }
 
   // Initialize distance to first waypoint
-  int closest_wp = path_size - 1;
+  int closest_wp = 0;
   double dist = getPlaneDistance(current_waypoints_.getWaypointPosition(0),
                                  current_pose_.pose.position);
 
@@ -302,18 +302,15 @@ void PurePursuit::getClosestWaypoint() {
     double t_dist = getPlaneDistance(current_waypoints_.getWaypointPosition(i),
                                      current_pose_.pose.position);
     if (t_dist < dist) {
-      // Found a closer waypoint, store dist and keep searching
+      // Found a closer waypoint, store it and keep searching
       dist = t_dist;
-    } else {
-      // Distance is not decreasing, prev waypt was closest so stop searching
-      closest_wp = i - 1;
-      break;
+      closest_wp = i;
     }
   }
 
   // Store closest waypoint as output
   closest_waypoint_idx_ = closest_wp;
-  //ROS_ERROR_STREAM("wp = " << closest_waypoint_idx_ << " dist = " << dist);
+  //ROS_ERROR_STREAM("closest wp = " << closest_waypoint_idx_ << " dist = " << dist);
   return;
 }
 


### PR DESCRIPTION
When testing on the simulator test lot track 2, the waypoints are very sparse and the car reaches the end of the list so to be able to turn sharply enough, the waypoint follower needs some fixes to be able to pick the correct target lookahead point.  With these fixes (and some adjustments to waypoint updater node that will be submitted in another PR), the car is able to make the sharp turn and follow the waypoints properly on the test lot track.  This is toward issue #26.