### PR TITLE
Add ROS launch file for styx simulator track 2

### DIFF
--- a/ros/launch/styx_track2.launch
+++ b/ros/launch/styx_track2.launch
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Enable message timing statistics for rqt_graph analysis -->
+    <rosparam param="enable_statistics">true</rosparam>
+
+    <!-- Simulator Bridge -->
+    <include file="$(find styx)/launch/server.launch" />
+
+    <!--DBW Node -->
+    <include file="$(find twist_controller)/launch/dbw_sim.launch"/>
+
+    <!--Waypoint Loader -->
+    <include file="$(find waypoint_loader)/launch/waypoint_loader_site.launch"/>
+
+    <!--Waypoint Follower Node -->
+    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>
+
+    <!--Waypoint Updater Node -->
+    <include file="$(find waypoint_updater)/launch/waypoint_updater.launch"/>
+
+    <!--Traffic Light Detector Node -->
+    <include file="$(find tl_detector)/launch/tl_detector.launch"/>
+
+    <!--Traffic Light Locations and Camera Config -->
+    <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+
+    <!--Visualization Node -->
+    <include file="$(find visualization)/launch/vis_node.launch"/>
+</launch>


### PR DESCRIPTION
Add a ROS launch file to use the styx simulator track 2 that loads the test site churchlot waypoints.  This is preparation for issue #26.