### PR TITLE
DBW: Tweaks to split throttle/brake LPF tau and initialize from 0

### DIFF
--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -2,10 +2,13 @@
 class LowPassFilter(object):
     def __init__(self, tau, ts):
         self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+        self.b = tau / ts / (tau / ts + 1.)
 
         self.last_val = 0.
-        self.ready = False
+
+        # Initialize from last_val = 0 instead of allowing an initial step
+        # change on activation when dbw_enabled turns ON
+        self.ready = True
 
     def get(self):
         return self.last_val

--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -28,7 +28,8 @@ class Controller(object):
         self.braking_to_throttle_threshold_ratio = 4. / 3.
         self.manual_braking_upper_velocity_limit = 1.5
         self.braking_torque_to_stop = 50
-        self.lpf_tau = 0.1
+        self.lpf_tau_throttle = 0.1
+        self.lpf_tau_brake = 1.0
 
         self.yaw_controller = YawController(
             wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle)
@@ -36,9 +37,11 @@ class Controller(object):
         self.dynamic_reconf_server = Server(
             DynReconfConfig, self.handle_dynamic_variable_update)
 
-        self.throttle_lpf = LowPassFilter(
-            self.lpf_tau, default_update_interval)
-        self.brake_lpf = LowPassFilter(self.lpf_tau, default_update_interval)
+        self.throttle_lpf = LowPassFilter(self.lpf_tau_throttle,
+                                          default_update_interval)
+
+        self.brake_lpf = LowPassFilter(self.lpf_tau_brake,
+                                       default_update_interval)
 
     def handle_dynamic_variable_update(self, config, level):
         # reset PID controller to use new parameters


### PR DESCRIPTION
Small tweaks to split throttle/brake LPF tau so that brake command response can be slower (brake torque reaction is much faster than powertrain throttle response so stronger smoothing may be needed for brake pedal command), and to initialize LPF starting from 0 instead of allowing an initial unfiltered step change on first activation when dbw_enabled turns ON.  This is toward issue #28.