### PR TITLE
Waypoint Updater: Reduce # of waypts and set init ptr back to 0

### DIFF
--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -11,7 +11,7 @@ gen.add("dyn_test_stoplight_wp",   int_t, 0, "TESTING next stopline wp",
 gen.add("dyn_update_rate",         int_t, 0, "rate (Hz) at which final waypoints published",
         10, 1, 50)
 gen.add("dyn_lookahead_wps",       int_t, 0, "number of final waypoints to send",
-        70, 10,  100)
+        30, 10,  100)
 gen.add("dyn_default_velocity", double_t, 0, "top speed to use (mps)",
         10.7, 0.0, 100.0)
 gen.add("dyn_default_accel",    double_t, 0, "accel/decel rate (m/s) to use",

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -69,7 +69,7 @@ class WaypointUpdater(object):
         self.prev_step_a = 0.0
         self.lights = None
         self.final_waypoints = []
-        self.final_waypoints_start_ptr = 250  # 0
+        self.final_waypoints_start_ptr = 0
         self.back_search = False
         self.last_search_distance = None
         self.last_search_time = None


### PR DESCRIPTION
As preparation for issue #26 testing the simulator churchlot site track 2, need to reduce the number of published final waypoints and set initial waypoint pointer index to start from 0.  The churchlot only has 61 total waypoints and the car starts from the middle at waypoint 26.