### PR TITLE
Increase DBW velocity proportional control response

### DIFF
--- a/ros/src/twist_controller/cfg/DynReconf.cfg
+++ b/ros/src/twist_controller/cfg/DynReconf.cfg
@@ -8,7 +8,7 @@ PACKAGE = "twist_controller"
 
 gen = ParameterGenerator()
 
-gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.1, 0, 4)
+gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.3, 0, 4)
 gen.add("dyn_velo_integral_control", double_t, 0, "Velocity integral control constant", 0.01, 0, 4.0)
 
 gen.add("dyn_braking_proportional_control", double_t, 0, "Braking proportional control constant", 300, 0, 1000)


### PR DESCRIPTION
After testing against DBW bag data (and seeing the new DBW tutorial video), increasing the velocity proportional control constant from 0.1 to 0.3 and integral component from 0.01 to 0.1 seems prudent.

For #51 