### PR TITLE
DBW node accepts deceleration intention from upstream to prevent early braking

### DIFF
--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -10,7 +10,7 @@ from jmt import JMT, JMTDetails, JMTD_waypoint
 
 from geometry_msgs.msg import PoseStamped, TwistStamped
 from styx_msgs.msg import Lane, Waypoint, TrafficLightArray, TrafficLight
-from std_msgs.msg import String, Int32
+from std_msgs.msg import Bool, String, Int32
 from dynamic_reconfigure.server import Server
 from waypoint_updater.cfg import DynReconfConfig
 
@@ -117,6 +117,10 @@ class WaypointUpdater(object):
 
         self.pubs['/final_waypoints'] = rospy.Publisher('/final_waypoints',
                                                         Lane, queue_size=1)
+        
+        # publish a boolean for acceleration vs deceleration intention
+        self.pubs['/is_decelerating'] = rospy.Publisher('/is_decelerating',
+                                                        Bool, queue_size=1)
 
         # self.dyn_reconf_srv = Server(DynReconfConfig, self.dyn_vars_cb)
         # move to waypoints_cb so no collision - seems like a bad idea but


### PR DESCRIPTION
Per [slack discussion](https://carnd.slack.com/archives/G8SCYKNSZ/p1522517708000157?thread_ts=1522516602.000020&cid=G8SCYKNSZ), this adds a message flow from the waypoint updater to the DBW node to signal the intention of deceleration. This information is useful to prevent the DBW node from applying braking when it's not desired.

Simulation testing shows that this works to prevent unnecessary braking at low target speed (2.7m/s).