### PR TITLE
Waypoint Follower: Fix negative target velocity

### DIFF
--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -370,22 +370,22 @@ geometry_msgs::TwistStamped PurePursuit::outputTwist(geometry_msgs::Twist t) con
 
   double v = t.linear.x;
   double omega = t.angular.z;
+  double omega_abs = fabs(omega);
 
-  if(fabs(omega) < ERROR){
+  if(omega_abs < ERROR){
 
     return twist;
   }
 
-  double max_v = g_lateral_accel_limit / omega;
+  double max_v = g_lateral_accel_limit / omega_abs;
 
 
-  double a = v * omega;
+  double a = v * omega_abs;
   ROS_INFO("lateral accel = %lf", a);
 
-  twist.twist.linear.x = fabs(a) > g_lateral_accel_limit ? max_v
-                    : v;
+  twist.twist.linear.x = fabs(a) > g_lateral_accel_limit ? max_v : v;
   twist.twist.angular.z = omega;
-
+  
   return twist;
 }
 


### PR DESCRIPTION
The waypoint follower pure pursuit code calculates a lateral G limit that is used to guard the target linear velocity.  However, it calculates this guard velocity by using the angular velocity omega, which can be positive or negative depending on the turning direction, and if the turning direction has negative omega, the guarded linear velocity may calculate as a negative target linear velocity which doesn't make sense.

This fix prevents the negative target linear velocity by using the absolute value of omega for the velocity guard calculations.  This is for issue #54. 