### PR TITLE
Waypoint Updater: Fix crash if get_closest_wp() called while wp's are appending

### DIFF
--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -272,6 +272,8 @@ class WaypointUpdater(object):
             s = 0.0
             max_velocity = 0.0
             wpt = None  # just to stop linter complaining
+            t_waypoints = []
+            t_waypoints_2d = []
 
             for lanemsg_wpt in lane_msg.waypoints:
 
@@ -284,13 +286,16 @@ class WaypointUpdater(object):
                                     position.y)**2)
 
                 wpt = JMTD_waypoint(lanemsg_wpt, cntr, s)
-                self.waypoints.append(wpt)
-                self.waypoints_2d.append([wpt.get_x(), wpt.get_y()])
+                t_waypoints.append(wpt)
+                t_waypoints_2d.append([wpt.get_x(), wpt.get_y()])
 
                 if max_velocity < wpt.get_maxV():
                     max_velocity = wpt.get_maxV()
                 # end if
                 cntr += 1
+
+            self.waypoints = t_waypoints
+            self.waypoints_2d = t_waypoints_2d
             self.waypoint_tree = KDTree(self.waypoints_2d)
 
             rospy.loginfo("waypoints_cb {} waypoints loaded, last waypoint "

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -147,7 +147,7 @@ class WaypointUpdater(object):
             self.rate.sleep()
         while not rospy.is_shutdown():
 
-            if self.waypoints:
+            if self.waypoints and self.waypoints_2d and self.waypoint_tree:
                 self.send_waypoints()
             self.rate.sleep()
 


### PR DESCRIPTION
I hit a rare race condition crash I think, where get_closest_wp() was called before the KD tree object had finished building, so I think it judged that self.waypoints existed while it was still being appended and built.  Here's a quick fix, but this should be very rare.