### PR TITLE
Waypoint Updater: Idea to get stopped state with manual braking

### DIFF
--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -17,7 +17,7 @@ gen.add("dyn_default_velocity", double_t, 0, "top speed to use (mps)",
 gen.add("dyn_default_accel",    double_t, 0, "accel/decel rate (m/s) to use",
         1.2, 0.5, 5.0)
 gen.add("dyn_tl_buffer",        double_t, 0, "buffer distance (m) to stop at before traffic light wp",
-        3.5, 0.0, 5.0)
+        4.0, 0.0, 5.0)
 gen.add("dyn_creep_zone",       double_t, 0, "zone before stoplight where no speedup beyond creep",
         20.0, 0.0, 35.0)
 gen.add("dyn_jmt_time_factor",  double_t, 0, "factor to extend jmt accel / decel time ",

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -860,15 +860,14 @@ class WaypointUpdater(object):
                 # Todo evaluate if we need to keep going
                 rospy.logdebug("Now within tl_buffer = {:4.3f}"
                               .format(self.dyn_tl_buffer))
-                if self.waypoints[self.final_waypoints_start_ptr].get_v() <=\
-                        self.handoff_velocity: 
+                if self.velocity <= self.handoff_velocity:
                     self.set_stopped(self.final_waypoints_start_ptr, self.
                                  lookahead_wps)
                 else:
                     rospy.logdebug("Within buffer, but not travelling at creeping speed")
                     recalc = self.produce_slowdown(self.final_waypoints_start_ptr,
                         self.lookahead_wps,
-                        dist_to_tl - (self.dyn_tl_buffer - 1.0))
+                        dist_to_tl)
 
             elif dist_to_tl < self.dyn_creep_zone + self.dyn_tl_buffer:
                 if self.waypoints[self.final_waypoints_start_ptr].get_v() <=\
@@ -879,7 +878,7 @@ class WaypointUpdater(object):
                         rospy.logwarn("now start to slowdown")
                     recalc = self.produce_slowdown(self.final_waypoints_start_ptr,
                                                self.lookahead_wps,
-                                               dist_to_tl - (self.dyn_tl_buffer - 1.0))
+                                               dist_to_tl)
             else:
                 # not sure when this might trigger but not match next if statement - then 
                 # reduce car velocity to 0.0 stoping before lights
@@ -889,7 +888,7 @@ class WaypointUpdater(object):
                 if dist_to_tl - self.dyn_tl_buffer > self.min_stop_distance:
                     recalc = self.produce_slowdown(self.final_waypoints_start_ptr,
                                                self.lookahead_wps,
-                                               dist_to_tl - (self.dyn_tl_buffer - 1.0))
+                                               dist_to_tl)
                 else:
                     rospy.logwarn("how did I get here? at ptr = {}".format(self.final_waypoints_start_ptr))
             # end if else


### PR DESCRIPTION
With DBW's latest manual braking working at the end of slowdowns, the car might stop before it enters the tl_buffer zone so the waypoint updater gets stuck in slowdown state.  To try to get the stopped state to trigger, this idea moves the target min speed all the way to the light position and slightly expands the tl_buffer zone.  Once the car stops within the tl_buffer zone, the condition to set stopped state also changes to be based on actual velocity < handoff_velocity, instead of the target velocity which might still be stuck slightly higher than the handoff_velocity.