### PR TITLE
TL Detector: Change log setting and use temp lists for appending

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="log" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
-    <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="log" cwd="node"/>
+    <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="log" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -161,21 +161,26 @@ class TLDetector(object):
 
     def waypoints_cb(self, waypoints):
         """Callback fuction for list of all waypoints."""
-        self.waypoints = waypoints
+        t_waypoints = waypoints
 
         # Build KD tree for closest waypoint search
-        self.waypoints_2d = []
-        for wp in self.waypoints.waypoints:
-            self.waypoints_2d.append([wp.pose.pose.position.x,
-                                      wp.pose.pose.position.y])
-        self.waypoint_tree = KDTree(self.waypoints_2d)
+        t_waypoints_2d = []
+        for wp in t_waypoints.waypoints:
+            t_waypoints_2d.append([wp.pose.pose.position.x,
+                                   wp.pose.pose.position.y])
+        t_waypoint_tree = KDTree(t_waypoints_2d)
+
+        self.waypoints = t_waypoints
+        self.waypoints_2d = t_waypoints_2d
+        self.waypoint_tree = t_waypoint_tree
 
         # Build list of closest waypoint to each stop line position
-        self.stop_line_waypoints = []
+        t_stop_line_waypoints = []
         for pts in self.stop_line_positions:
             sl_wp = self.get_closest_waypoint(pts[0], pts[1])
-            self.stop_line_waypoints.append(sl_wp)
+            t_stop_line_waypoints.append(sl_wp)
 
+        self.stop_line_waypoints = t_stop_line_waypoints
 
     def traffic_cb(self, msg):
         self.lights = msg.lights

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -288,13 +288,13 @@ class TLDetector(object):
                 ntl_state = self.previous_light_state
 
 
-        if self.pose and self.waypoints:
+        if self.pose and self.waypoint_tree:
             car_position = self.get_closest_waypoint(self.pose.pose.position.x,
                                                      self.pose.pose.position.y)
 
         # State = 0 : Red
         if ((ntl_state != 4) or (self.light_classifier is None)):
-            if car_position:
+            if car_position and self.waypoint_tree:
                 for tl in self.lights:
                     nearest_waypoint = self.get_closest_waypoint(
                                                     tl.pose.pose.position.x,


### PR DESCRIPTION
- Change log output setting to log file instead of screen (prevents loginfo from showing up on screen, only goes to log file, but logwarn and logerr still go to screen and log file)

- Use temp variables for appending waypoints and waypoint KD trees to prevent crash from race condition of calling get_closest_waypoint() while self.waypoints is still in the process of building.