### PR TITLE
DBW: Reduce brake LPF tau for faster release

### DIFF
--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -25,7 +25,7 @@ class Controller(object):
         self.manual_braking_upper_velocity_limit = 1.5
         self.braking_torque_to_stop = 100
         self.lpf_tau_throttle = 0.3
-        self.lpf_tau_brake = 0.5
+        self.lpf_tau_brake = 0.3
         self.lpf_tau_steering = 0.1
 
         self.max_braking_torque = (


### PR DESCRIPTION
For issue #115, reduce brake LPF tau from 0.5 to 0.3 (to same value as throttle) to allow faster brake release to reduce delay to start accelerating from a stop.  In simulator, the time from 100 Nm brake to 0 Nm is reduced by ~0.7 sec.