### PR TITLE
DBW: Tweak throttle/brake gains and decel threshold

### DIFF
--- a/ros/src/twist_controller/cfg/DynReconf.cfg
+++ b/ros/src/twist_controller/cfg/DynReconf.cfg
@@ -8,10 +8,10 @@ PACKAGE = "twist_controller"
 
 gen = ParameterGenerator()
 
-gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.3, 0, 4)
+gen.add("dyn_velo_proportional_control", double_t, 0, "Velocity proportional control constant", 0.2, 0, 4)
 gen.add("dyn_velo_integral_control", double_t, 0, "Velocity integral control constant", 0.01, 0, 4.0)
 
-gen.add("dyn_braking_proportional_control", double_t, 0, "Braking proportional control constant", 300, 0, 1000)
+gen.add("dyn_braking_proportional_control", double_t, 0, "Braking proportional control constant", 200, 0, 1000)
 gen.add("dyn_braking_integral_control", double_t, 0, "Braking integral control constant", 0, 0, 4.0)
 
 exit(gen.generate(PACKAGE, "twist_controller", "DynReconf"))

--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -20,7 +20,7 @@ class Controller(object):
         self.max_throttle = max_throttle
         self.default_update_interval = default_update_interval
         self.velocity_increase_limit_constant = 0.25
-        self.velocity_decrease_limit_constant = 0.1
+        self.velocity_decrease_limit_constant = 0.05
         self.braking_to_throttle_threshold_ratio = 4. / 3.
         self.manual_braking_upper_velocity_limit = 1.5
         self.braking_torque_to_stop = 100


### PR DESCRIPTION
This is for issue #117:
- Reduce throttle P gain to reduce accel overshoot seen in Udacity site result bag data
- Reduce brake P gain to smooth out decel speed control during slowdown in simulator
- Reduce brake activation threshold to start braking earlier in decel to keep closer track of target speed profile