### PR TITLE
DBW: Increase steering LPF tau smoothing

### DIFF
--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -26,7 +26,7 @@ class Controller(object):
         self.braking_torque_to_stop = 100
         self.lpf_tau_throttle = 0.3
         self.lpf_tau_brake = 0.3
-        self.lpf_tau_steering = 0.1
+        self.lpf_tau_steering = 0.2
 
         self.max_braking_torque = (
             vehicle_mass + fuel_capacity * GAS_DENSITY) * abs(max_deceleration) * wheel_radius


### PR DESCRIPTION
In the video of the v1.0 site test, the steering wheel has some rapid rotation at the beginning and end of the test.  Increasing the steering LPF tau can help smooth out the rate of these large rotations, while still being able to track the overall steering movements needed during the drive.

See the attached chart showing the result of the dbw_test script run on the `1150531_2018-04-12-17-02-51.bag` data, showing the original steering command with tau 0.1 vs the proposed steering with tau 0.2:

[steering_tau_retune.xlsx](https://github.com/team-fusionx/CarND-Capstone/files/1918889/steering_tau_retune.xlsx)
