### PR TITLE
TL Detector: Initialize state_count to pass threshold to send initial light_wp

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -36,6 +36,7 @@ class TLClassifier(object):
         self.labels = np.array(['green', 'none', 'red', 'yellow'])
         self.resize_width = 224
         self.resize_height = 224
+        rospy.logwarn('TL Classifier init complete.')
 
     def get_classification(self, image):
         """Determines the color of the traffic light in the image

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -92,6 +92,7 @@ class TLDetector(object):
         sub6 = rospy.Subscriber('/image_color', Image, self.image_cb, queue_size=1)
 
         self.rate = rospy.Rate(UPDATE_RATE)
+        rospy.logwarn('TL Detector init complete.')
         self.loop()
 
     def loop(self):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -58,7 +58,7 @@ class TLDetector(object):
         self.busy = False
 
         self.last_wp = -1
-        self.state_count = 0
+        self.state_count = STATE_COUNT_THRESHOLD
         self.L_update = False
         self.light_change_to_red_or_yellow = False
 
@@ -113,6 +113,10 @@ class TLDetector(object):
                 of times till we start using it. Otherwise the previous stable state is
                 used.
                 '''
+
+                rospy.loginfo('TL: state_count={}, self.state={}, state={}'
+                              .format(self.state_count, self.state, state))
+
                 if self.state != state:
                     if (self.state == TrafficLight.YELLOW 
                         and state == TrafficLight.RED):


### PR DESCRIPTION
Initialize self.state_count to pass the state count threshold on the first loop so the initial TL waypoint message will be sent with the correct initial light_wp value instead of the default initialized -1 value to allow Waypoint Updater to start with the correct driving state if starting the test already close to a light.  Also, add some logging for state and state count values.