### PR TITLE
TL Detector: Add condition on main loop to wait for pose and waypoints

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -97,7 +97,7 @@ class TLDetector(object):
 
     def loop(self):
         while not rospy.is_shutdown():
-            if self.has_image:        
+            if self.has_image and self.pose and self.waypoint_tree:
 
                 """ Added the following to confirm classifier light state 
                     - to rule out any latency issue


### PR DESCRIPTION
To prevent sending an initial waypoint of -1 on initial loop, add a condition to wait until self.pose and self.waypoint_tree have also finished initializing from their callbacks so that the get_closest_waypoint() check can return the actual waypoint index for the first published message to Waypoint Updater.