### PR TITLE
Add buffer beyond traffic light stop target

### DIFF
--- a/ros/src/visualization/rqt_multiplot_simulation.xml
+++ b/ros/src/visualization/rqt_multiplot_simulation.xml
@@ -419,7 +419,7 @@
                                     <field>data</field>
                                     <field_type>0</field_type>
                                     <scale>
-                                        <absolute_maximum>500</absolute_maximum>
+                                        <absolute_maximum>750</absolute_maximum>
                                         <absolute_minimum>0</absolute_minimum>
                                         <relative_maximum>0</relative_maximum>
                                         <relative_minimum>-1000</relative_minimum>
@@ -470,7 +470,7 @@
                                     <field>pedal_cmd</field>
                                     <field_type>0</field_type>
                                     <scale>
-                                        <absolute_maximum>500</absolute_maximum>
+                                        <absolute_maximum>750</absolute_maximum>
                                         <absolute_minimum>0</absolute_minimum>
                                         <relative_maximum>0</relative_maximum>
                                         <relative_minimum>-1000</relative_minimum>

--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -19,7 +19,7 @@ gen.add("dyn_default_accel",    double_t, 0, "accel/decel rate (m/s) to use",
 gen.add("dyn_tl_buffer",        double_t, 0, "buffer distance (m) to stop at before traffic light wp",
         3.0, 0.0, 5.0)
 gen.add("dyn_buffer_offset",    double_t, 0, "offset into buffer to target stopping point",
-        2.5, 0.0, 5.0)
+        0.5, 0.0, 5.0)
 gen.add("dyn_creep_zone",       double_t, 0, "zone before stoplight where no speedup beyond creep",
         20.0, 0.0, 35.0)
 # gen.add("dyn_jmt_time_factor",  double_t, 0, "factor to extend jmt accel / decel time ",


### PR DESCRIPTION
Add `self.extra_tl_stop_buffer` which is valid if `self.is_decelerating` flag is set (when car is stopped or slowing down).  This prevents the `self.next_tl_wp` from being reset to -1, if the car passes  beyond the target stopping point.

Also added in checks for delayed update of pose, and delayed waypoint_updater loop to diagnose issues with simulator.

also changed scale in rqt_multiplot for braking.