### PR TITLE
DBW node resets braking LPF when going from manual braking to acceleration, to prevent slow speed up from stop.

### DIFF
--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -21,3 +21,6 @@ class LowPassFilter(object):
 
         self.last_val = val
         return val
+
+    def reset(self):
+        self.ready = False


### PR DESCRIPTION
Per [Slack conversation](https://carnd.slack.com/archives/G8SCYKNSZ/p1528825626000228).

This resets the DBW brake low pass filter when switching to acceleration after manual braking. This should allow the vehicle to accelerate immediately, rather than waiting for the filtered braking value to lower through the lpf for several cycles.