### PR TITLE
Faster acceleration from stopped

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -14,7 +14,7 @@ import math
 import time
 from scipy.spatial import KDTree
 
-STATE_COUNT_THRESHOLD = 3 # Means we need 3 consecutives
+STATE_COUNT_THRESHOLD = 3 # Means we need 4 consecutives
 UPDATE_RATE = 10
 CLASSIFY_BY_GROUND_TRUTH = False
 tl_decoder = ['RED','YELLOW','GREEN','','UNKNOWN']

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -14,7 +14,7 @@ import math
 import time
 from scipy.spatial import KDTree
 
-STATE_COUNT_THRESHOLD = 3
+STATE_COUNT_THRESHOLD = 2 # Means we need 3 consecutives
 UPDATE_RATE = 10
 CLASSIFY_BY_GROUND_TRUTH = False
 tl_decoder = ['RED','YELLOW','GREEN','','UNKNOWN']

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -14,7 +14,7 @@ import math
 import time
 from scipy.spatial import KDTree
 
-STATE_COUNT_THRESHOLD = 2 # Means we need 3 consecutives
+STATE_COUNT_THRESHOLD = 3 # Means we need 3 consecutives
 UPDATE_RATE = 10
 CLASSIFY_BY_GROUND_TRUTH = False
 tl_decoder = ['RED','YELLOW','GREEN','','UNKNOWN']

--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -1,5 +1,5 @@
 import time
-
+import math
 import rospy
 
 from dynamic_reconfigure.server import Server
@@ -75,8 +75,9 @@ class Controller(object):
         timestep = self.compute_timestep()
         velocity_error = target_linear_velocity - current_linear_velocity
 
-        if (target_linear_velocity == 0 and current_linear_velocity == 0):
+        if (target_linear_velocity == 0 and math.fabs(current_linear_velocity) == 0.0):
             # reset integrators if we're at a stop
+            #current_linear_velocity = 0.0
             self.reset()
 
         limit_constant = self.velocity_increase_limit_constant if velocity_error > 0 else self.velocity_decrease_limit_constant

--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -75,7 +75,7 @@ class Controller(object):
         timestep = self.compute_timestep()
         velocity_error = target_linear_velocity - current_linear_velocity
 
-        if (target_linear_velocity == 0 and current_linear_velocity == 0.0):
+        if (target_linear_velocity == 0 and current_linear_velocity == 0):
             # reset integrators if we're at a stop
             self.reset()
 

--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -1,5 +1,5 @@
 import time
-import math
+
 import rospy
 
 from dynamic_reconfigure.server import Server
@@ -75,9 +75,8 @@ class Controller(object):
         timestep = self.compute_timestep()
         velocity_error = target_linear_velocity - current_linear_velocity
 
-        if (target_linear_velocity == 0 and math.fabs(current_linear_velocity) == 0.0):
+        if (target_linear_velocity == 0 and current_linear_velocity == 0.0):
             # reset integrators if we're at a stop
-            #current_linear_velocity = 0.0
             self.reset()
 
         limit_constant = self.velocity_increase_limit_constant if velocity_error > 0 else self.velocity_decrease_limit_constant

--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -17,7 +17,7 @@ gen.add("dyn_default_velocity", double_t, 0, "top speed to use (mps)",
 gen.add("dyn_default_accel",    double_t, 0, "accel/decel rate (m/s) to use",
         0.8, 0.5, 5.0)
 gen.add("dyn_tl_buffer",        double_t, 0, "buffer distance (m) to stop at before traffic light wp",
-        1.0, 0.0, 5.0)
+        1.5, 0.0, 5.0)
 gen.add("dyn_buffer_offset",    double_t, 0, "offset into buffer to target stopping point",
         0.5, 0.0, 5.0)
 gen.add("dyn_creep_zone",       double_t, 0, "zone before stoplight where no speedup beyond creep",

--- a/ros/src/waypoint_updater/cfg/DynReconf.cfg
+++ b/ros/src/waypoint_updater/cfg/DynReconf.cfg
@@ -17,7 +17,7 @@ gen.add("dyn_default_velocity", double_t, 0, "top speed to use (mps)",
 gen.add("dyn_default_accel",    double_t, 0, "accel/decel rate (m/s) to use",
         0.8, 0.5, 5.0)
 gen.add("dyn_tl_buffer",        double_t, 0, "buffer distance (m) to stop at before traffic light wp",
-        3.0, 0.0, 5.0)
+        1.0, 0.0, 5.0)
 gen.add("dyn_buffer_offset",    double_t, 0, "offset into buffer to target stopping point",
         0.5, 0.0, 5.0)
 gen.add("dyn_creep_zone",       double_t, 0, "zone before stoplight where no speedup beyond creep",

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -5,7 +5,7 @@
         <!-- using dynparams now                           -->
         <param name="initial_accel" type="double" value="3.0" />
         <param name="handoff_velocity" type="double" value="1.0" />
-        <param name="min_moving_velocity" type="double" value="1.5" />
+        <param name="min_moving_velocity" type="double" value="1.0" />
         <param name="max_accel" type="double" value="5.0" />
         <param name="max_desired_jerk" type="double" value="1.0" />
         <param name="abs_max_jerk" type="double" value="6.0" />

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -3,9 +3,9 @@
     <node pkg="waypoint_updater" type="waypnt_updater.py" name="waypoint_updater">
         <!-- way to set params in param server from launch -->
         <!-- using dynparams now                           -->
-        <param name="initial_accel" type="double" value="0.3" />
+        <param name="initial_accel" type="double" value="3.0" />
         <param name="handoff_velocity" type="double" value="1.0" />
-        <param name="min_moving_velocity" type="double" value="1.0" />
+        <param name="min_moving_velocity" type="double" value="1.5" />
         <param name="max_accel" type="double" value="5.0" />
         <param name="max_desired_jerk" type="double" value="1.0" />
         <param name="abs_max_jerk" type="double" value="6.0" />

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -3,11 +3,11 @@
     <node pkg="waypoint_updater" type="waypnt_updater.py" name="waypoint_updater">
         <!-- way to set params in param server from launch -->
         <!-- using dynparams now                           -->
-        <param name="initial_accel" type="double" value="3.0" />
+        <param name="initial_accel" type="double" value="1.0" />
         <param name="handoff_velocity" type="double" value="1.0" />
         <param name="min_moving_velocity" type="double" value="1.0" />
         <param name="max_accel" type="double" value="5.0" />
-        <param name="max_desired_jerk" type="double" value="1.0" />
+        <param name="max_desired_jerk" type="double" value="1.5" />
         <param name="abs_max_jerk" type="double" value="6.0" />
     </node>
 </launch>

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -898,7 +898,7 @@ class WaypointUpdater(object):
         # no need to increment offset in this case
         offset = 0
 
-        first_wp_velocity = 2.0 * self.min_moving_velocity
+        first_wp_velocity = 3.0 * self.min_moving_velocity
 
         velocity = min(max(first_wp_velocity, self.waypoints[start_ptr].get_v()),
                        0.9 * self.waypoints[start_ptr].get_maxV())
@@ -980,9 +980,9 @@ class WaypointUpdater(object):
             self.state = 'creeping'
         for ptr in range(start_ptr, start_ptr + num_wps):
             mod_ptr = ptr % len(self.waypoints)
-            self.waypoints[mod_ptr].JMTD.set_VAJt(self.min_moving_velocity,
+            self.waypoints[mod_ptr].JMTD.set_VAJt(1.5 * self.min_moving_velocity,
                                                   0.0, 0.0, 0.0)
-            self.waypoints[mod_ptr].set_v(self.min_moving_velocity)
+            self.waypoints[mod_ptr].set_v(1.5 * self.min_moving_velocity)
             self.waypoints[mod_ptr].JMT_ptr = -1
 
     def set_waypoints_velocity(self):

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -898,11 +898,21 @@ class WaypointUpdater(object):
         # no need to increment offset in this case
         offset = 0
 
-        velocity = max(self.min_moving_velocity,
-                       self.waypoints[start_ptr].get_v())
+        first_wp_velocity = 2.0 * self.min_moving_velocity
+
+        velocity = min(max(first_wp_velocity, self.waypoints[start_ptr].get_v()),
+                       0.9 * self.waypoints[start_ptr].get_maxV())
+
         self.waypoints[start_ptr].set_v(velocity)
+
+        if velocity <= first_wp_velocity:
+            init_accel = 0.0
+        else:
+            init_accel = self.init_accel
+
         self.waypoints[start_ptr].JMTD.set_VAJt(
-                    velocity, self.initial_accel, 0.0, 0.0)
+                    velocity, init_accel, 0.0, 0.0)
+
         return offset
 
     def generate_speedup(self, start_ptr, end_ptr):

--- a/ros/src/waypoint_updater/waypnt_updater.py
+++ b/ros/src/waypoint_updater/waypnt_updater.py
@@ -898,17 +898,17 @@ class WaypointUpdater(object):
         # no need to increment offset in this case
         offset = 0
 
-        first_wp_velocity = 3.0 * self.min_moving_velocity
+        first_wp_velocity = 1.0 * self.min_moving_velocity
 
         velocity = min(max(first_wp_velocity, self.waypoints[start_ptr].get_v()),
-                       0.9 * self.waypoints[start_ptr].get_maxV())
+                       0.75 * self.waypoints[start_ptr].get_maxV())
 
         self.waypoints[start_ptr].set_v(velocity)
 
-        if velocity <= first_wp_velocity:
+        if velocity < first_wp_velocity:
             init_accel = 0.0
         else:
-            init_accel = self.init_accel
+            init_accel = self.initial_accel
 
         self.waypoints[start_ptr].JMTD.set_VAJt(
                     velocity, init_accel, 0.0, 0.0)


### PR DESCRIPTION
Changed so velocity on first waypoint when starting from stopped is set to 3.0 m/s instead of 1.0 m/s.  This reduces time to get to 2.0 m/s from about 1.8 s to 1.0 s.  Jerk and acceleration values remain within limits on simulator with this change.
Creeping speed is also increased to 1.5 m/s from 1.0 m/s.
Reduced number of consecutive traffic light signal identifications from 4 to 3 to cut status change time down by 0.1 secs.

