### PR TITLE
TL Detector: Raise classifier confidence threshold and add RED->UNKNOWN

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -106,7 +106,7 @@ class TLClassifier(object):
                       yhat[y_class]*100, dt1.to_sec(), dt2.to_sec())
 
         self.current_light = TrafficLight.UNKNOWN
-        if (yhat[y_class] > 0.5):
+        if (yhat[y_class] > 0.7):
             if y_class == 0:
                 self.current_light = TrafficLight.GREEN
             elif y_class == 2:


### PR DESCRIPTION
- Based on classifier accuracy data from FX-v2.2 Carla site test, raise classification confidence threshold so that <70% will become UNKNOWN light state.
- Add RED->UNKNOWN transition to be allowed if car is already stopped for the red light and light state becomes unknown (possible green light).  Velocity signal smallest non-zero value in data is ~0.2 m/s so threshold to judge stopped is set to 0.3 m/s to be slightly above this.