### PR TITLE
DBW: Increase steering LPF tau to 0.4 to reduce initial steer correction

### DIFF
--- a/ros/src/twist_controller/twist_controller_mod.py
+++ b/ros/src/twist_controller/twist_controller_mod.py
@@ -26,7 +26,7 @@ class Controller(object):
         self.manual_braking_torque_up_rate = 300
         self.lpf_tau_throttle = 0.3
         self.lpf_tau_brake = 0.3
-        self.lpf_tau_steering = 0.2
+        self.lpf_tau_steering = 0.4
         self.manual_braking = False
 
         self.max_braking_torque = (


### PR DESCRIPTION
During recent site test, Carla starts with a large initial steering correction to get on the waypoints that causes the traffic light to go out of the camera image.  Increasing the steering LPF tau to 0.4 can help slow down and reduce the initial steering correction to try to keep the light in the image while still allowing enough response to track the overall turns around the lot.