### PR TITLE
Waypoint Follower: Increase min lookahead distance for Carla test

### DIFF
--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -99,7 +99,7 @@ public:
     , const_lookahead_distance_(4.0)
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
-    , minimum_lookahead_distance_(4.0) // shorten for tight turn in test lot
+    , minimum_lookahead_distance_(6.0) // shorten for tight turn in test lot
     , displacement_threshold_(0.05)
     , relative_angle_threshold_(0.5)
     , waypoint_set_(false)


### PR DESCRIPTION
During Carla site test, the test was started with the vehicle parallel and offset to the left of the waypoints.  The initial steering correction to get on the waypoints ended up pointing the car away from the light when it stopped at the stop line.  Increasing the minimum lookahead distance for the pure pursuit algorithm can reduce the amount of this initial correction because the steering will target a waypoint a little further ahead of the car.

During simulation track 2 testing with the original church lot waypoints, the initial steering correction amount is reduced from a peak of 2 deg to 0.6 deg and the car is still able to turn sharply enough to make it around the course.

During simulation track 2 with the extracted Carla test waypoints, the car is still able to turn enough to follow the waypoints around the course with the increased 6m min lookahead distance.