### PR TITLE
TL Detector: Add dummy image for CLASSIFY_BY_GROUND_TRUTH

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -54,7 +54,7 @@ class TLDetector(object):
 
         if CLASSIFY_BY_GROUND_TRUTH:
             self.light_classifier = None
-            self.image_q.append({'num': 1, 'image': np.zeros((1, 600, 800, 3))})
+            self.image_q.append({'num': 1, 'image': np.zeros((800, 600, 3))})
         else:
             use_image_clips = rospy.get_param('~use_image_clips', False)
             use_image_array = rospy.get_param('~use_image_array', False)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -54,7 +54,9 @@ class TLDetector(object):
 
         if CLASSIFY_BY_GROUND_TRUTH:
             self.light_classifier = None
-            self.image_q.append({'num': 1, 'image': np.zeros((800, 600, 3))})
+            dummy_img_array = np.zeros((600, 800, 3), dtype=np.uint8)
+            dummy_img_msg = self.bridge.cv2_to_imgmsg(dummy_img_array, "bgr8")
+            self.image_q.append({'num': 1, 'image': dummy_img_msg})
         else:
             use_image_clips = rospy.get_param('~use_image_clips', False)
             use_image_array = rospy.get_param('~use_image_array', False)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -54,6 +54,7 @@ class TLDetector(object):
 
         if CLASSIFY_BY_GROUND_TRUTH:
             self.light_classifier = None
+            self.image_q.append({'num': 1, 'image': np.zeros((1, 600, 800, 3))})
         else:
             use_image_clips = rospy.get_param('~use_image_clips', False)
             use_image_array = rospy.get_param('~use_image_array', False)


### PR DESCRIPTION
After switching logic to process light state by `len(self.image_q)`, need to add a dummy image for the `CLASSIFY_BY_GROUND_TRUTH == True` condition so the length will be non-zero and allow ground truth pass-through processing.